### PR TITLE
EN-22 Modify employee contracts status

### DIFF
--- a/src/main/java/com/entropyteam/entropay/config/WebSecurityConfig.java
+++ b/src/main/java/com/entropyteam/entropay/config/WebSecurityConfig.java
@@ -20,7 +20,6 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 import org.springframework.security.web.SecurityFilterChain;
 import com.entropyteam.entropay.auth.TokenService;
 
-import lombok.AllArgsConstructor;
 
 @Configuration
 @EnableWebSecurity

--- a/src/main/java/com/entropyteam/entropay/employees/controllers/ContractController.java
+++ b/src/main/java/com/entropyteam/entropay/employees/controllers/ContractController.java
@@ -3,9 +3,8 @@ package com.entropyteam.entropay.employees.controllers;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 import com.entropyteam.entropay.common.BaseController;
 import com.entropyteam.entropay.employees.dtos.ContractDto;
 import com.entropyteam.entropay.employees.services.ContractService;
@@ -14,10 +13,15 @@ import com.entropyteam.entropay.employees.services.ContractService;
 @CrossOrigin
 @RequestMapping(value = "/contracts", produces = MediaType.APPLICATION_JSON_VALUE)
 public class ContractController extends BaseController<ContractDto, UUID> {
-
+    private final ContractService contractService;
     @Autowired
     public ContractController(ContractService contractService) {
         super(contractService);
+        this.contractService = contractService;
     }
 
+    @PutMapping("/{id}/status")
+    public ResponseEntity<ContractDto> modifyStatus(@PathVariable UUID id, @RequestParam boolean active) {
+        return ResponseEntity.ok(contractService.modifyStatus(id, active));
+    }
 }

--- a/src/main/java/com/entropyteam/entropay/employees/controllers/EmployeeController.java
+++ b/src/main/java/com/entropyteam/entropay/employees/controllers/EmployeeController.java
@@ -1,11 +1,13 @@
 package com.entropyteam.entropay.employees.controllers;
 
 import java.util.UUID;
+
+import com.entropyteam.entropay.employees.dtos.ContractDto;
+import com.entropyteam.entropay.employees.services.ContractService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 import com.entropyteam.entropay.common.BaseController;
 import com.entropyteam.entropay.employees.dtos.EmployeeDto;
 import com.entropyteam.entropay.employees.services.EmployeeService;
@@ -14,7 +16,6 @@ import com.entropyteam.entropay.employees.services.EmployeeService;
 @CrossOrigin
 @RequestMapping(value = "/employees", produces = MediaType.APPLICATION_JSON_VALUE)
 public class EmployeeController extends BaseController<EmployeeDto, UUID> {
-
     @Autowired
     public EmployeeController(EmployeeService employeeService) {
         super(employeeService);

--- a/src/main/java/com/entropyteam/entropay/employees/dtos/ContractDto.java
+++ b/src/main/java/com/entropyteam/entropay/employees/dtos/ContractDto.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
+
 import com.entropyteam.entropay.employees.models.Contract;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
@@ -20,6 +21,7 @@ public record ContractDto(
         LocalDate startDate,
         @JsonFormat(pattern = "yyyy-MM-dd") LocalDate endDate,
         boolean deleted,
+        boolean active,
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime createdAt,
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime modifiedAt
@@ -30,8 +32,27 @@ public record ContractDto(
         this(
                 contract.getId(), contract.getCompany().getId(), contract.getEmployee().getId(),
                 contract.getRole().getId(), contract.getSeniority().getId(), contract.getHoursPerWeek(), contract.getCostRate(),
-                contract.getVacations(), contract.getStartDate(), contract.getEndDate(), contract.isDeleted(),
+                contract.getVacations(), contract.getStartDate(), contract.getEndDate(), contract.isDeleted(), contract.isActive(),
                 contract.getCreatedAt(), contract.getModifiedAt()
+        );
+    }
+
+    public ContractDto withActive(boolean active) {
+        return this.active == active ? this : new ContractDto(
+                this.id,
+                this.companyId,
+                this.employeeId,
+                this.positionId,
+                this.seniorityId,
+                this.hoursPerWeek,
+                this.costRate,
+                this.vacations,
+                this.startDate,
+                this.endDate,
+                this.deleted,
+                active,
+                this.createdAt,
+                this.modifiedAt
         );
     }
 }

--- a/src/main/java/com/entropyteam/entropay/employees/models/Address.java
+++ b/src/main/java/com/entropyteam/entropay/employees/models/Address.java
@@ -10,6 +10,9 @@ public class Address {
     private String zipCode;
     private String addressLine;
 
+    public Address() {
+    }
+
     public String getCountry() {
         return country;
     }

--- a/src/main/java/com/entropyteam/entropay/employees/models/Contract.java
+++ b/src/main/java/com/entropyteam/entropay/employees/models/Contract.java
@@ -39,6 +39,9 @@ public class Contract extends BaseEntity {
     @Column
     private Integer vacations;
 
+    @Column
+    private boolean active;
+
     public Contract() {
     }
 
@@ -48,6 +51,7 @@ public class Contract extends BaseEntity {
         this.hoursPerWeek = entity.hoursPerWeek();
         this.costRate = entity.costRate();
         this.vacations = entity.vacations();
+        this.active = entity.active();
     }
 
     public Company getCompany() {
@@ -121,4 +125,13 @@ public class Contract extends BaseEntity {
     public void setVacations(Integer vacations) {
         this.vacations = vacations;
     }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+
 }

--- a/src/main/java/com/entropyteam/entropay/employees/models/Employee.java
+++ b/src/main/java/com/entropyteam/entropay/employees/models/Employee.java
@@ -1,7 +1,6 @@
 package com.entropyteam.entropay.employees.models;
 
 import java.time.LocalDate;
-import java.util.HashSet;
 import java.util.Set;
 import javax.persistence.*;
 
@@ -35,7 +34,7 @@ public class Employee extends BaseEntity {
             joinColumns = { @JoinColumn(name = "employee_id") },
             inverseJoinColumns = { @JoinColumn(name = "role_id") }
     )
-    Set<Role> roles = new HashSet<>();
+    private Set<Role> roles;
 
     public Employee() {
     }

--- a/src/main/java/com/entropyteam/entropay/employees/models/Role.java
+++ b/src/main/java/com/entropyteam/entropay/employees/models/Role.java
@@ -5,7 +5,6 @@ import javax.persistence.*;
 import com.entropyteam.entropay.common.BaseEntity;
 import com.entropyteam.entropay.employees.dtos.RoleDto;
 
-import java.util.HashSet;
 import java.util.Set;
 
 @Entity(name = "Role")
@@ -16,7 +15,7 @@ public class Role extends BaseEntity {
     private String name;
 
     @ManyToMany(fetch = FetchType.LAZY, mappedBy = "roles")
-    private Set<Employee> employees = new HashSet<>();
+    private Set<Employee> employees;
 
     public Role() {
     }

--- a/src/main/java/com/entropyteam/entropay/employees/repositories/ContractRepository.java
+++ b/src/main/java/com/entropyteam/entropay/employees/repositories/ContractRepository.java
@@ -1,6 +1,7 @@
 package com.entropyteam.entropay.employees.repositories;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import com.entropyteam.entropay.common.BaseRepository;
 import com.entropyteam.entropay.employees.models.Contract;
@@ -8,4 +9,5 @@ import com.entropyteam.entropay.employees.models.Contract;
 public interface ContractRepository extends BaseRepository<Contract, UUID> {
 
     List<Contract> findAllByDeletedIsFalse();
+    Optional<Contract> findContractByEmployeeIdAndActiveIsTrue(UUID employeeId);
 }

--- a/src/main/resources/db/migration/V8.0__DDL_modify_contract_table.sql
+++ b/src/main/resources/db/migration/V8.0__DDL_modify_contract_table.sql
@@ -1,0 +1,31 @@
+ALTER TABLE contract ADD COLUMN active BOOLEAN DEFAULT FALSE;
+
+CREATE OR REPLACE FUNCTION on_modify_update_modified_at()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+    AS
+$$
+BEGIN
+    UPDATE contract SET modified_at = CURRENT_TIMESTAMP WHERE id = NEW.id;
+    RETURN NEW;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION on_active_status_validate_unique()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+AS
+$$
+BEGIN
+     IF (NEW.active = TRUE) AND ((SELECT 1 FROM contract WHERE active = 1 AND employee_id = NEW.employee_id) > 0) THEN
+         RAISE EXCEPTION 'An employee can not have multiple active contracts';
+     end if;
+END
+$$;
+
+CREATE TRIGGER unique_contract_active
+    BEFORE INSERT OR UPDATE
+    ON contract
+    FOR EACH ROW
+    WHEN (NEW.active = TRUE)
+    EXECUTE PROCEDURE on_active_status_validate_unique();

--- a/src/test/java/com/entropyteam/entropay/employees/controllers/ContractControllerTest.java
+++ b/src/test/java/com/entropyteam/entropay/employees/controllers/ContractControllerTest.java
@@ -1,0 +1,96 @@
+package com.entropyteam.entropay.employees.controllers;
+
+import com.entropyteam.entropay.employees.dtos.ContractDto;
+import com.entropyteam.entropay.employees.services.ContractService;
+import com.entropyteam.entropay.employees.testUtils.testUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ContractControllerTest {
+    @Mock
+    ContractService contractService;
+    @InjectMocks
+    ContractController underTest;
+
+    @DisplayName("Test create happy path")
+    @Test
+    public void testCreate() {
+        // given
+        ContractDto contractDto = new ContractDto(testUtils.aContract());
+        ResponseEntity<ContractDto> expected = ResponseEntity.ok(contractDto);
+
+        // when
+        when(contractService.create(any())).thenReturn(contractDto);
+
+        // then
+        ResponseEntity<ContractDto> actual = underTest.create(contractDto);
+
+        assertEquals(expected, actual);
+        verify(contractService, times(1)).create(eq(contractDto));
+        verifyNoMoreInteractions(contractService);
+    }
+
+    @DisplayName("Test create when ContractService throws exception")
+    @Test
+    public void testCreateWhenContractServiceThrowsException() {
+        // given
+        ContractDto contractDto = new ContractDto(testUtils.aContract());
+
+        // when
+        when(contractService.create(any())).thenThrow(new RuntimeException("Test exception thrown!!"));
+
+        // then
+        assertThrows(RuntimeException.class, () ->
+                        underTest.create(contractDto),
+                "RuntimeException was expected");
+        verifyNoMoreInteractions(contractService);
+    }
+
+    @DisplayName("Test modifyStatus happy path")
+    @Test
+    public void testModifyStatus() {
+        // given
+        ContractDto contractDto = new ContractDto(testUtils.aContract());
+        boolean setActive = true;
+        ResponseEntity<ContractDto> expected = ResponseEntity.ok(contractDto);
+
+        // when
+        when(contractService.modifyStatus(any(), anyBoolean())).thenReturn(contractDto);
+
+        // then
+        ResponseEntity<ContractDto> actual = underTest.modifyStatus(contractDto.id(), setActive);
+
+        assertEquals(expected, actual);
+        verify(contractService, times(1)).modifyStatus(eq(contractDto.id()), eq(setActive));
+        verifyNoMoreInteractions(contractService);
+    }
+
+    @DisplayName("Test modifyStatus when ContractService throws exception")
+    @Test
+    public void testModifyStatusWhenContractServiceThrowsException() {
+        // given
+        ContractDto contractDto = new ContractDto(testUtils.aContract());
+        boolean setActive = true;
+
+        // when
+        when(contractService.modifyStatus(any(), anyBoolean())).thenThrow(new RuntimeException("Test exception thrown!!"));
+
+        // then
+        assertThrows(RuntimeException.class, () ->
+                        underTest.modifyStatus(contractDto.id(), setActive),
+                "RuntimeException was expected");
+        verifyNoMoreInteractions(contractService);
+
+    }
+}

--- a/src/test/java/com/entropyteam/entropay/employees/services/ContractServiceTest.java
+++ b/src/test/java/com/entropyteam/entropay/employees/services/ContractServiceTest.java
@@ -1,0 +1,292 @@
+package com.entropyteam.entropay.employees.services;
+
+import com.entropyteam.entropay.common.BaseService;
+import com.entropyteam.entropay.employees.dtos.ContractDto;
+import com.entropyteam.entropay.employees.models.Contract;
+import com.entropyteam.entropay.employees.repositories.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.entropyteam.entropay.employees.testUtils.testUtils.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ContractServiceTest {
+    private final UUID ACTIVE_CONTRACT_ID = UUID.fromString("6616a253-a57c-4bb2-817e-32215ab71eee");
+    private final UUID EXISTENT_CONTRACT_ID = UUID.fromString("5516a253-a57c-4bb2-817e-32215ab71fff");
+    @Mock
+    EmployeeRepository employeeRepository;
+    @Mock
+    ContractRepository contractRepository;
+    @Mock
+    CompanyRepository companyRepository;
+    @Mock
+    RoleRepository roleRepository;
+    @Mock
+    SeniorityRepository seniorityRepository;
+    @Captor
+    ArgumentCaptor<Contract> contractCaptor;
+    @InjectMocks
+    @Spy
+    ContractService underTest;
+    private Contract existentContract;
+    private Contract activeContract;
+
+    @BeforeEach
+    public void setUp() {
+        existentContract = aContract();
+        existentContract.setId(EXISTENT_CONTRACT_ID);
+        activeContract = aContract();
+        activeContract.setId(ACTIVE_CONTRACT_ID);
+    }
+
+    @DisplayName("When employee has existent active contract deactivate it, create new active contract and save")
+    @Test
+    public void testCreateWhenEmployeeHasExistentAnActiveContract() {
+        // given
+        ContractDto requestedContract = new ContractDto(existentContract);
+
+        // when
+        when(employeeRepository.findById(any())).thenReturn(Optional.of(anEmployee()));
+        when(companyRepository.findById(any())).thenReturn(Optional.of(aCompany()));
+        when(roleRepository.findById(any())).thenReturn(Optional.of(aRole()));
+        when(seniorityRepository.findById(any())).thenReturn(Optional.of(aSeniority()));
+        when(contractRepository.save(any())).thenReturn(existentContract);
+        when(contractRepository.findContractByEmployeeIdAndActiveIsTrue(any())).thenReturn(Optional.of(existentContract));
+
+        // then
+        ContractDto response = underTest.create(new ContractDto(existentContract));
+
+        assertEquals(new ContractDto(existentContract), response);
+
+        verify(employeeRepository, times(1)).findById(eq(requestedContract.employeeId()));
+        verify(contractRepository, times(1)).saveAndFlush(contractCaptor.capture());
+        verify(contractRepository, times(1)).findContractByEmployeeIdAndActiveIsTrue(any());
+        verify((BaseService) underTest, times(1)).create(eq(requestedContract.withActive(true)));
+
+        assertFalse(contractCaptor.getValue().isActive());
+    }
+
+    @DisplayName("When employee doesn't have active contracts then just create and save requested")
+    @Test
+    public void testCreateWhenEmployeeDoesNotHaveActiveContracts() {
+        // given
+        ContractDto requestedContract = new ContractDto(existentContract);
+
+        // when
+        when(employeeRepository.findById(any())).thenReturn(Optional.of(anEmployee()));
+        when(companyRepository.findById(any())).thenReturn(Optional.of(aCompany()));
+        when(roleRepository.findById(any())).thenReturn(Optional.of(aRole()));
+        when(seniorityRepository.findById(any())).thenReturn(Optional.of(aSeniority()));
+        when(contractRepository.save(any())).thenReturn(existentContract);
+        when(contractRepository.findContractByEmployeeIdAndActiveIsTrue(any())).thenReturn(Optional.empty());
+
+        // then
+        ContractDto response = underTest.create(new ContractDto(existentContract));
+
+        assertEquals(new ContractDto(existentContract), response);
+
+        verify(employeeRepository, times(1)).findById(eq(requestedContract.employeeId()));
+        verify(contractRepository, never()).saveAndFlush(any());
+        verify(contractRepository, times(1)).findContractByEmployeeIdAndActiveIsTrue(any());
+        verify((BaseService) underTest, times(1)).create(eq(requestedContract.withActive(true)));
+    }
+
+    @DisplayName("Test create when ContractRepository throws exception")
+    @Test
+    public void testCreateWhenContractRepositoryThrowsException() {
+        // given
+        ContractDto requestedContract = new ContractDto(existentContract);
+
+        // when
+        when(contractRepository.findContractByEmployeeIdAndActiveIsTrue(any())).thenThrow(new RuntimeException("Test exception thrown!!"));
+
+        // then
+        assertThrows(RuntimeException.class, () ->
+                        underTest.create(new ContractDto(existentContract)),
+                "RuntimeException was expected");
+
+        verifyNoMoreInteractions(contractRepository);
+    }
+
+    @DisplayName("Test modifyStatus when setActive is true and there is an existing active contract, should deactivate existing and activate current.")
+    @Test
+    public void testModifyStatusWhenSetActiveIsTrueAndExistentContractIsActive() {
+        // given
+        boolean setActive = true;
+        existentContract.setActive(false);
+
+        Contract activated = aContract();
+        activated.setId(EXISTENT_CONTRACT_ID);
+        activated.setActive(true);
+        ContractDto expected = new ContractDto(activated);
+
+        // when
+        when(contractRepository.findById(any())).thenReturn(Optional.of(existentContract));
+        when(contractRepository.findContractByEmployeeIdAndActiveIsTrue(any())).thenReturn(Optional.of(activeContract));
+        when(contractRepository.save(any())).thenReturn(activated);
+
+        // then
+        ContractDto actual = underTest.modifyStatus(EXISTENT_CONTRACT_ID, setActive);
+
+        Assertions.assertEquals(expected, actual);
+        verify(contractRepository, times(1)).findById(eq(existentContract.getId()));
+        verify(contractRepository, times(1)).findContractByEmployeeIdAndActiveIsTrue(existentContract.getEmployee().getId());
+        verify(contractRepository, times(1)).saveAndFlush(contractCaptor.capture());
+        verify(contractRepository, times(1)).save(contractCaptor.capture());
+        verifyNoMoreInteractions(contractRepository);
+
+        List<Contract> capturedValues = contractCaptor.getAllValues();
+        assertTrue(capturedValues.stream().anyMatch(contract -> existentContract.getId().equals(contract.getId()) && contract.isActive() == setActive));
+        assertTrue(capturedValues.stream().anyMatch(contract -> activeContract.getId().equals(contract.getId()) && !contract.isActive()));
+    }
+
+    @DisplayName("Test modifyStatus when setActive is true and there is not active contracts, should activate current.")
+    @Test
+    public void testModifyStatusWhenSetActiveIsTrue() {
+        // given
+        boolean setActive = true;
+        existentContract.setActive(false);
+
+        Contract activated = aContract();
+        activated.setId(EXISTENT_CONTRACT_ID);
+        activated.setActive(true);
+        ContractDto expected = new ContractDto(activated);
+
+        // when
+        when(contractRepository.findById(any())).thenReturn(Optional.of(existentContract));
+        when(contractRepository.save(any())).thenReturn(activated);
+
+        // then
+        ContractDto actual = underTest.modifyStatus(EXISTENT_CONTRACT_ID, setActive);
+
+        assertEquals(expected, actual);
+        verify(contractRepository, times(1)).findById(eq(existentContract.getId()));
+        verify(contractRepository, times(1)).findContractByEmployeeIdAndActiveIsTrue(existentContract.getEmployee().getId());
+        verify(contractRepository, times(1)).save(contractCaptor.capture());
+        verifyNoMoreInteractions(contractRepository);
+
+        List<Contract> capturedValues = contractCaptor.getAllValues();
+        assertTrue(capturedValues.stream().anyMatch(contract -> existentContract.getId().equals(contract.getId())
+                && contract.isActive() == setActive));
+    }
+
+    @DisplayName("Test modifyStatus when setActive is true and contract is already active, should throw exception")
+    @Test
+    public void testModifyStatusWhenSetActiveIsTrueAndContractIsAlreadyActive() {
+        // given
+        boolean setActive = true;
+        existentContract.setActive(true);
+
+        // when
+        when(contractRepository.findById(any())).thenReturn(Optional.of(existentContract));
+
+        // then
+        ResponseStatusException thrown = assertThrows(ResponseStatusException.class, () ->
+                        underTest.modifyStatus(existentContract.getId(), setActive),
+                "ResponseStatusException was expected");
+
+        assertEquals(HttpStatus.NO_CONTENT, thrown.getStatus());
+        verify(contractRepository, times(1)).findById(eq(existentContract.getId()));
+        verifyNoMoreInteractions(contractRepository);
+    }
+
+    @DisplayName("Test modifyStatus when setActive is false and contract is already inactive, should throw exception")
+    @Test
+    public void testModifyStatusWhenSetActiveIsFalseAndContractIsAlreadyInactive() {
+        // given
+        boolean setActive = false;
+        existentContract.setActive(false);
+
+        // when
+        when(contractRepository.findById(any())).thenReturn(Optional.of(existentContract));
+
+        // then
+        ResponseStatusException thrown = assertThrows(ResponseStatusException.class, () ->
+                        underTest.modifyStatus(existentContract.getId(), setActive),
+                "ResponseStatusException was expected");
+
+        assertEquals(HttpStatus.NO_CONTENT, thrown.getStatus());
+        verify(contractRepository, times(1)).findById(eq(existentContract.getId()));
+        verifyNoMoreInteractions(contractRepository);
+    }
+
+    @DisplayName("Test modifyStatus when setActive is false should deactivate contract.")
+    @Test
+    public void testModifyStatusWhenSetActiveIsFalse() {
+        // given
+        boolean setActive = false;
+        existentContract.setActive(true);
+
+        Contract deactivated = aContract();
+        deactivated.setId(EXISTENT_CONTRACT_ID);
+        deactivated.setActive(false);
+        ContractDto expected = new ContractDto(deactivated);
+
+        // when
+        when(contractRepository.findById(any())).thenReturn(Optional.of(existentContract));
+        when(contractRepository.save(any())).thenReturn(deactivated);
+
+        // then
+        ContractDto actual = underTest.modifyStatus(EXISTENT_CONTRACT_ID, setActive);
+
+        Assertions.assertEquals(expected, actual);
+        assertFalse(actual.active());
+        verify(contractRepository, times(1)).findById(eq(existentContract.getId()));
+        verify(contractRepository, times(1)).save(contractCaptor.capture());
+        verifyNoMoreInteractions(contractRepository);
+
+        List<Contract> capturedValues = contractCaptor.getAllValues();
+        assertTrue(capturedValues.stream().anyMatch(contract -> existentContract.getId().equals(contract.getId())
+                && contract.isActive() == setActive));
+    }
+
+    @DisplayName("Test modifyStatus when contract does not exists")
+    @Test
+    public void testModifyStatusWhenContractDoesntExists() {
+        // given
+        boolean setActive = false;
+
+        // when
+        when(contractRepository.findById(any())).thenReturn(Optional.empty());
+
+        // then
+        ResponseStatusException thrown = assertThrows(ResponseStatusException.class, () ->
+                        underTest.modifyStatus(existentContract.getId(), setActive),
+                "ResponseStatusException was expected");
+
+        assertEquals(HttpStatus.NOT_FOUND, thrown.getStatus());
+        verify(contractRepository, times(1)).findById(eq(existentContract.getId()));
+        verifyNoMoreInteractions(contractRepository);
+    }
+
+    @DisplayName("Test modifyStatus when ContractRepository throws exception")
+    @Test
+    public void testModifyStatusWhenContractRepositoryThrowsException() {
+        // given
+        boolean setActive = false;
+
+        // when
+        when(contractRepository.findById(any())).thenThrow(new RuntimeException("Test exception thrown!!"));
+
+        // then
+        RuntimeException thrown = assertThrows(RuntimeException.class, () ->
+                        underTest.modifyStatus(existentContract.getId(), setActive),
+                "RuntimeException was expected");
+        verifyNoMoreInteractions(contractRepository);
+    }
+}

--- a/src/test/java/com/entropyteam/entropay/employees/testUtils/testUtils.java
+++ b/src/test/java/com/entropyteam/entropay/employees/testUtils/testUtils.java
@@ -1,0 +1,74 @@
+package com.entropyteam.entropay.employees.testUtils;
+
+import com.entropyteam.entropay.employees.models.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Set;
+
+public class testUtils {
+    public static Contract aContract() {
+        Contract contract = new Contract();
+        contract.setCompany(aCompany());
+        contract.setEmployee(anEmployee());
+        contract.setRole(aRole());
+        contract.setSeniority(aSeniority());
+        contract.setStartDate(LocalDate.of(2019, 5, 22));
+        contract.setHoursPerWeek(48);
+        contract.setCostRate(BigDecimal.valueOf(21, 4));
+        contract.setVacations(15);
+        contract.setActive(true);
+        return contract;
+    }
+
+    public static Seniority aSeniority() {
+        Seniority seniority = new Seniority();
+        seniority.setName("Senior");
+        return seniority;
+    }
+
+    public static Role aRole() {
+        Role role = new Role();
+        role.setName("Software Engineers");
+        role.setEmployees(Set.of(anEmployee()));
+        return role;
+    }
+
+    public static Employee anEmployee() {
+        Employee employee = new Employee();
+        employee.setFirstName("Satoshi");
+        employee.setLastName("Nakamoto");
+        employee.setPersonalEmail("satoshin@gmx.com");
+        employee.setBirthDate(LocalDate.of(1975, 4, 5));
+        employee.setCountry("Japan");
+        employee.setTaxId("201234310");
+        employee.setEmergencyContactFullName("Dorian Nakamoto");
+        employee.setEmergencyContactPhone("+1503123513");
+        return employee;
+    }
+
+    public static Company aCompany() {
+        Company company = new Company();
+        company.setName("Test Company");
+        company.setAddress(anAddress());
+        company.setTenant(aTenant());
+        return company;
+    }
+
+    public static Tenant aTenant() {
+        Tenant tenant = new Tenant();
+        tenant.setName("The Great Wall");
+        tenant.setDisplayName("TGW");
+        return tenant;
+    }
+
+    public static Address anAddress() {
+        Address address = new Address();
+        address.setCountry("USA");
+        address.setState("Massachusetts");
+        address.setCity("Springfield");
+        address.setAddressLine("Ever Green St.");
+        address.setZipCode("01089");
+        return address;
+    }
+}


### PR DESCRIPTION
# Description :pencil:

New features:

1. Create a new contract.
a. ContractService verifies if an employee has an existing active contract, and deactivates it before creating the new one.
b. A new flyway migration script has been added with a boolean attribute _active_ for contracts. The default value is intentionally set to false to avoid unintended active contracts on the DB.
c. A trigger on the DB has been created to ensure every INSERT or UPDATE validates that there is only one active contract per employee.
d. **PLUS**: A trigger on the DB has been created to update _modified_at_ attribute when any change is performed.

2. Modify an existing contract status.
a. Created new endpoint `/contracts/{id}` for PATCH requests.
b. ContractService will validate data consistency and also deactivate any previous active contract if the reason for the patch is to activate an old contract

**Important to review:** :bangbang:
I've encountered some issues while sending NULL attributes for "active" in the contract requests. Currently a NULL will be saved, and this is not the expected behavior. Due to difficulties with the DTOs, I couldn't find the appropriate way to validate this, or force "active" on new contracts.
Would it be ok to implement Model Mapper instead of the current conversion DTO-Entity?


## Link to ticket :link:

https://entropyteam.atlassian.net/browse/EN-22

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? :microscope:

Added UnitTests to the new code.
Tested making live requests in the local environment.

1- DB before inserting a new active contract.
![image](https://user-images.githubusercontent.com/55709674/204173169-74a2014b-2364-41dd-a844-32e59e6a7540.png)

2- Create new active contract request
![image](https://user-images.githubusercontent.com/55709674/204173211-62bfcbd5-3391-470f-81bf-90a78bf79603.png)

3- DB after inserting the new contract.
![image](https://user-images.githubusercontent.com/55709674/204173257-cc1bc4d1-7399-4e14-8bd6-8b0bbc753127.png)

4- Modify contract #6d08 to active request
![image](https://user-images.githubusercontent.com/55709674/204173470-32208894-5c0b-4853-bf80-b28d80dd6a88.png)

5- DB after modifying status
![image](https://user-images.githubusercontent.com/55709674/204173482-22b57962-d90c-4684-92a2-1cd5c7a2a809.png)

6- Testing DB trigger: manually activating a second contract for the same employee
![image](https://user-images.githubusercontent.com/55709674/204173755-33776f01-6716-4cc6-ba0c-0fcda63d6ed1.png)


## Checklist: :white_check_mark:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules