### PR TITLE
EN-22 Modify contract validation trigger

### DIFF
--- a/src/main/resources/db/migration/V9.0_modify_contract_validation_trigger.sql
+++ b/src/main/resources/db/migration/V9.0_modify_contract_validation_trigger.sql
@@ -1,0 +1,12 @@
+CREATE OR REPLACE FUNCTION on_active_status_validate_unique()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+AS
+$$
+BEGIN
+    IF (NEW.active = TRUE) AND ((SELECT 1 FROM contract WHERE active = TRUE AND employee_id = NEW.employee_id) > 0) THEN
+        RAISE EXCEPTION 'An employee can not have multiple active contracts';
+    end if;
+    return new;
+END
+$$;


### PR DESCRIPTION
# Description :pencil:

Detected errors while creating new contracts. SQL Function on_active_status_validate_unique() was comparing an integer with a boolean throwing an error.

![image](https://user-images.githubusercontent.com/55709674/208794952-c4b67a9a-763c-479a-b4a6-77e403285130.png)


## Link to ticket :link:

https://entropyteam.atlassian.net/browse/EN-22

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? :microscope:

Live tests on local environment sending POST requests to create a new contract with different "active" values. All end up creating a new contract.

![image](https://user-images.githubusercontent.com/55709674/208795116-78cbe565-a917-4c77-aadc-9860bc7e24d6.png)

When trying to activate a second contract for the same employee, the trigger does return an error. This error can only be triggered while modifying manually the DB.

![image](https://user-images.githubusercontent.com/55709674/208798627-c87265ae-7b3c-43b6-92e7-fcde9214244e.png)
