### PR TITLE
EN-72: Contract status based on Due date

### DIFF
--- a/src/main/java/com/entropyteam/entropay/employees/repositories/ContractRepository.java
+++ b/src/main/java/com/entropyteam/entropay/employees/repositories/ContractRepository.java
@@ -9,5 +9,5 @@ import com.entropyteam.entropay.employees.models.Contract;
 public interface ContractRepository extends BaseRepository<Contract, UUID> {
 
     List<Contract> findAllByDeletedIsFalse();
-    Optional<Contract> findContractByEmployeeIdAndActiveIsTrue(UUID employeeId);
+    Optional<Contract> findContractByEmployeeIdAndActiveIsTrueAndDeletedIsFalse(UUID employeeId);
 }

--- a/src/main/java/com/entropyteam/entropay/employees/services/ContractService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/services/ContractService.java
@@ -2,12 +2,10 @@ package com.entropyteam.entropay.employees.services;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
+import com.entropyteam.entropay.employees.models.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -18,12 +16,6 @@ import com.entropyteam.entropay.common.BaseRepository;
 import com.entropyteam.entropay.common.BaseService;
 import com.entropyteam.entropay.common.ReactAdminMapper;
 import com.entropyteam.entropay.employees.dtos.ContractDto;
-import com.entropyteam.entropay.employees.models.Company;
-import com.entropyteam.entropay.employees.models.Contract;
-import com.entropyteam.entropay.employees.models.Employee;
-import com.entropyteam.entropay.employees.models.PaymentSettlement;
-import com.entropyteam.entropay.employees.models.Role;
-import com.entropyteam.entropay.employees.models.Seniority;
 import com.entropyteam.entropay.employees.repositories.CompanyRepository;
 import com.entropyteam.entropay.employees.repositories.ContractRepository;
 import com.entropyteam.entropay.employees.repositories.EmployeeRepository;
@@ -132,11 +124,7 @@ public class ContractService extends BaseService<Contract, ContractDto, UUID> {
         contract.setEmployee(employee);
         contract.setRole(role);
         contract.setSeniority(seniority);
-        if (entity.paymentSettlement() == null) {
-            contract.setPaymentsSettlement(new HashSet<>());
-        } else {
-            contract.setPaymentsSettlement(new HashSet<>(entity.paymentSettlement().stream().map(PaymentSettlement::new).toList()));
-        }
+        contract.setPaymentsSettlement(entity.paymentSettlement() == null ?  Collections.emptySet() : entity.paymentSettlement().stream().map(PaymentSettlement::new).collect(Collectors.toSet()));
         return contract;
     }
 

--- a/src/main/java/com/entropyteam/entropay/employees/services/EmployeeService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/services/EmployeeService.java
@@ -3,14 +3,11 @@ package com.entropyteam.entropay.employees.services;
 import com.entropyteam.entropay.common.BaseRepository;
 import com.entropyteam.entropay.common.BaseService;
 import com.entropyteam.entropay.common.ReactAdminMapper;
+import com.entropyteam.entropay.employees.models.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.entropyteam.entropay.employees.dtos.EmployeeDto;
-import com.entropyteam.entropay.employees.models.Employee;
-import com.entropyteam.entropay.employees.models.PaymentInformation;
-import com.entropyteam.entropay.employees.models.Role;
-import com.entropyteam.entropay.employees.models.Technology;
 import com.entropyteam.entropay.employees.repositories.EmployeeRepository;
 import com.entropyteam.entropay.employees.repositories.PaymentInformationRepository;
 import com.entropyteam.entropay.employees.repositories.RoleRepository;
@@ -20,6 +17,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.Arrays;
+import java.util.HashSet;
 
 
 @Service
@@ -66,6 +64,11 @@ public class EmployeeService extends BaseService<Employee, EmployeeDto, UUID> {
 
         employee.setRoles(roles);
         employee.setTechnologies(technologies);
+        if (entity.paymentInformation() == null) {
+            employee.setPaymentsInformation(new HashSet<>());
+        } else {
+            employee.setPaymentsInformation(new HashSet<>(entity.paymentInformation().stream().map(PaymentInformation::new).toList()));
+        }
         return employee;
     }
 

--- a/src/main/java/com/entropyteam/entropay/employees/services/EmployeeService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/services/EmployeeService.java
@@ -3,15 +3,18 @@ package com.entropyteam.entropay.employees.services;
 import com.entropyteam.entropay.common.BaseRepository;
 import com.entropyteam.entropay.common.BaseService;
 import com.entropyteam.entropay.common.ReactAdminMapper;
-import com.entropyteam.entropay.employees.models.*;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import com.entropyteam.entropay.employees.dtos.EmployeeDto;
+import com.entropyteam.entropay.employees.models.Employee;
+import com.entropyteam.entropay.employees.models.PaymentInformation;
+import com.entropyteam.entropay.employees.models.Role;
+import com.entropyteam.entropay.employees.models.Technology;
 import com.entropyteam.entropay.employees.repositories.EmployeeRepository;
 import com.entropyteam.entropay.employees.repositories.PaymentInformationRepository;
 import com.entropyteam.entropay.employees.repositories.RoleRepository;
 import com.entropyteam.entropay.employees.repositories.TechnologyRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Set;
@@ -48,7 +51,6 @@ public class EmployeeService extends BaseService<Employee, EmployeeDto, UUID> {
         return employeeRepository;
     }
 
-    @Transactional
     @Override
     protected EmployeeDto toDTO(Employee entity) {
         List<PaymentInformation> paymentInformationList =
@@ -77,7 +79,7 @@ public class EmployeeService extends BaseService<Employee, EmployeeDto, UUID> {
     public EmployeeDto create(EmployeeDto employeeDto) {
         Employee entityToCreate = toEntity(employeeDto);
         Employee savedEntity = getRepository().save(entityToCreate);
-        paymentInformationService.create(savedEntity.getPaymentsInformation(), savedEntity);
+        paymentInformationService.createPaymentsInformation(savedEntity.getPaymentsInformation(), savedEntity);
         return toDTO(savedEntity);
     }
 
@@ -87,7 +89,7 @@ public class EmployeeService extends BaseService<Employee, EmployeeDto, UUID> {
         Employee entityToUpdate = toEntity(employeeDto);
         entityToUpdate.setId(employeeId);
         Employee savedEntity = getRepository().save(entityToUpdate);
-        paymentInformationService.update(employeeDto.paymentInformation(), savedEntity);
+        paymentInformationService.updatePaymentsInformation(employeeDto.paymentInformation(), savedEntity);
         return toDTO(savedEntity);
     }
 

--- a/src/main/java/com/entropyteam/entropay/employees/services/EmployeeService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/services/EmployeeService.java
@@ -74,7 +74,7 @@ public class EmployeeService extends BaseService<Employee, EmployeeDto, UUID> {
     public EmployeeDto create(EmployeeDto employeeDto) {
         Employee entityToCreate = toEntity(employeeDto);
         Employee savedEntity = getRepository().save(entityToCreate);
-        paymentInformationService.create(employeeDto.paymentInformation(), savedEntity);
+        paymentInformationService.create(savedEntity.getPaymentsInformation(), savedEntity);
         return toDTO(savedEntity);
     }
 

--- a/src/main/java/com/entropyteam/entropay/employees/services/EmployeeService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/services/EmployeeService.java
@@ -20,7 +20,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.Arrays;
-import java.util.HashSet;
+import java.util.Collections;
+import java.util.stream.Collectors;
 
 
 @Service
@@ -66,11 +67,7 @@ public class EmployeeService extends BaseService<Employee, EmployeeDto, UUID> {
 
         employee.setRoles(roles);
         employee.setTechnologies(technologies);
-        if (entity.paymentInformation() == null) {
-            employee.setPaymentsInformation(new HashSet<>());
-        } else {
-            employee.setPaymentsInformation(new HashSet<>(entity.paymentInformation().stream().map(PaymentInformation::new).toList()));
-        }
+        employee.setPaymentsInformation(entity.paymentInformation() == null ?  Collections.emptySet() : entity.paymentInformation().stream().map(PaymentInformation::new).collect(Collectors.toSet()));
         return employee;
     }
 

--- a/src/main/java/com/entropyteam/entropay/employees/services/PaymentInformationService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/services/PaymentInformationService.java
@@ -8,7 +8,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import com.entropyteam.entropay.common.BaseRepository;
 import com.entropyteam.entropay.common.BaseService;
 import com.entropyteam.entropay.common.ReactAdminMapper;
@@ -34,26 +33,22 @@ public class PaymentInformationService extends BaseService<PaymentInformation, P
         return paymentInformationRepository;
     }
 
-    @Transactional
     @Override
     protected PaymentInformationDto toDTO(PaymentInformation entity) {
         return new PaymentInformationDto(entity);
     }
 
-    @Transactional
     @Override
     protected PaymentInformation toEntity(PaymentInformationDto entity) {
         return new PaymentInformation(entity);
     }
 
-    @Transactional
-    protected Set<PaymentInformation> create(Set<PaymentInformation> paymentInformation, Employee savedEntity) {
+    public Set<PaymentInformation> createPaymentsInformation(Set<PaymentInformation> paymentInformation, Employee savedEntity) {
         paymentInformation = paymentInformation.stream().peek( p -> p.setEmployee(savedEntity)).collect(Collectors.toSet());
         return new HashSet<>(paymentInformationRepository.saveAll(paymentInformation));
     }
 
-    @Transactional
-    protected void update(List<PaymentInformationDto> paymentInformationDtos, Employee employee){
+    public void updatePaymentsInformation(List<PaymentInformationDto> paymentInformationDtos, Employee employee){
         List<PaymentInformation> paymentsInformationList = paymentInformationRepository.findAllByEmployeeIdAndDeletedIsFalse(employee.getId());
         List<PaymentInformation> paymentInformationRequest = paymentInformationDtos.stream().map(this::toEntity).toList();
         List<PaymentInformation> paymentInformationToDelete = new ArrayList<>();

--- a/src/main/java/com/entropyteam/entropay/employees/services/PaymentInformationService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/services/PaymentInformationService.java
@@ -47,8 +47,7 @@ public class PaymentInformationService extends BaseService<PaymentInformation, P
     }
 
     @Transactional
-    protected Set<PaymentInformation> create(List<PaymentInformationDto> paymentsInformation, Employee savedEntity) {
-        Set<PaymentInformation> paymentInformation = paymentsInformation.stream().map(PaymentInformation::new).collect(Collectors.toSet());
+    protected Set<PaymentInformation> create(Set<PaymentInformation> paymentInformation, Employee savedEntity) {
         paymentInformation = paymentInformation.stream().peek( p -> p.setEmployee(savedEntity)).collect(Collectors.toSet());
         return new HashSet<>(paymentInformationRepository.saveAll(paymentInformation));
     }

--- a/src/main/java/com/entropyteam/entropay/employees/services/PaymentSettlementService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/services/PaymentSettlementService.java
@@ -47,8 +47,7 @@ public class PaymentSettlementService  extends BaseService<PaymentSettlement, Pa
     }
 
     @Transactional
-    protected Set<PaymentSettlement> create(List<PaymentSettlementDto> paymentSettlementDtos, Contract savedEntity) {
-        Set<PaymentSettlement> paymentSettlement = paymentSettlementDtos.stream().map(PaymentSettlement::new).collect(Collectors.toSet());
+    protected Set<PaymentSettlement> create(Set<PaymentSettlement> paymentSettlement, Contract savedEntity) {
         paymentSettlement = paymentSettlement.stream().peek( p -> p.setContract(savedEntity)).collect(Collectors.toSet());
         return new HashSet<>(paymentSettlementRepository.saveAll(paymentSettlement));
     }

--- a/src/main/java/com/entropyteam/entropay/employees/services/PaymentSettlementService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/services/PaymentSettlementService.java
@@ -8,7 +8,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import com.entropyteam.entropay.common.BaseRepository;
 import com.entropyteam.entropay.common.BaseService;
 import com.entropyteam.entropay.common.ReactAdminMapper;
@@ -34,26 +33,22 @@ public class PaymentSettlementService  extends BaseService<PaymentSettlement, Pa
         return paymentSettlementRepository;
     }
 
-    @Transactional
     @Override
     protected PaymentSettlementDto toDTO(PaymentSettlement entity) {
         return new PaymentSettlementDto(entity);
     }
 
-    @Transactional
     @Override
     protected PaymentSettlement toEntity(PaymentSettlementDto entity) {
         return new PaymentSettlement(entity);
     }
 
-    @Transactional
-    protected Set<PaymentSettlement> create(Set<PaymentSettlement> paymentSettlement, Contract savedEntity) {
+    public Set<PaymentSettlement> createPaymentsSettlement(Set<PaymentSettlement> paymentSettlement, Contract savedEntity) {
         paymentSettlement = paymentSettlement.stream().peek( p -> p.setContract(savedEntity)).collect(Collectors.toSet());
         return new HashSet<>(paymentSettlementRepository.saveAll(paymentSettlement));
     }
 
-    @Transactional
-    protected void update(List<PaymentSettlementDto> paymentSettlementDtos, Contract contract){
+    public void updatePaymentsSettlement(List<PaymentSettlementDto> paymentSettlementDtos, Contract contract){
         List<PaymentSettlement> paymentsSettlementList = paymentSettlementRepository.findAllByContractIdAndDeletedIsFalse(contract.getId());
         List<PaymentSettlement> paymentSettlementRequest = paymentSettlementDtos.stream().map(this::toEntity).toList();
         List<PaymentSettlement> paymentSettlementToDelete = new ArrayList<>();

--- a/src/main/resources/db/migration/V25.0__DDL_remove_trigger_from_contract.sql
+++ b/src/main/resources/db/migration/V25.0__DDL_remove_trigger_from_contract.sql
@@ -1,0 +1,6 @@
+DROP FUNCTION on_modify_update_modified_at();
+
+DROP TRIGGER IF EXISTS unique_contract_active ON public.contract;
+
+DROP FUNCTION on_active_status_validate_unique();}
+

--- a/src/main/resources/db/migration/V25.0__DDL_remove_trigger_from_contract.sql
+++ b/src/main/resources/db/migration/V25.0__DDL_remove_trigger_from_contract.sql
@@ -2,5 +2,5 @@ DROP FUNCTION on_modify_update_modified_at();
 
 DROP TRIGGER IF EXISTS unique_contract_active ON public.contract;
 
-DROP FUNCTION on_active_status_validate_unique();}
+DROP FUNCTION on_active_status_validate_unique();
 

--- a/src/test/java/com/entropyteam/entropay/employees/services/ContractServiceTest.java
+++ b/src/test/java/com/entropyteam/entropay/employees/services/ContractServiceTest.java
@@ -149,23 +149,6 @@ class ContractServiceTest {
         verify((BaseService) underTest, times(1)).create(eq(requestedContract.withActive(true)));
     }
 
-    @DisplayName("Test create when ContractRepository throws exception")
-    @Test
-    public void testCreateWhenContractRepositoryThrowsException() {
-        // given
-        ContractDto requestedContract = new ContractDto(existentContract);
-
-        // when
-        when(contractRepository.findContractByEmployeeIdAndActiveIsTrueAndDeletedIsFalse(any())).thenThrow(
-                new RuntimeException("Test exception thrown!!"));
-
-        // then
-        assertThrows(RuntimeException.class, () ->
-                        underTest.create(new ContractDto(existentContract)),
-                "RuntimeException was expected");
-
-        verifyNoMoreInteractions(contractRepository);
-    }
 
     @DisplayName("Test modifyStatus when setActive is true and there is an existing active contract, should "
             + "deactivate existing and activate current.")

--- a/src/test/java/com/entropyteam/entropay/employees/services/ContractServiceTest.java
+++ b/src/test/java/com/entropyteam/entropay/employees/services/ContractServiceTest.java
@@ -100,7 +100,7 @@ class ContractServiceTest {
         when(roleRepository.findById(any())).thenReturn(Optional.of(aRole()));
         when(seniorityRepository.findById(any())).thenReturn(Optional.of(aSeniority()));
         when(contractRepository.save(any())).thenReturn(existentContract);
-        when(contractRepository.findContractByEmployeeIdAndActiveIsTrue(any())).thenReturn(
+        when(contractRepository.findContractByEmployeeIdAndActiveIsTrueAndDeletedIsFalse(any())).thenReturn(
                 Optional.of(existentContract));
         when(paymentSettlementService.create(any(), any())).thenReturn(null);
         when(paymentSettlementRepository.findAllByContractIdAndDeletedIsFalse(any())).thenReturn(
@@ -114,7 +114,7 @@ class ContractServiceTest {
 
         verify(employeeRepository, times(1)).findById(eq(requestedContract.employeeId()));
         verify(contractRepository, times(1)).saveAndFlush(contractCaptor.capture());
-        verify(contractRepository, times(1)).findContractByEmployeeIdAndActiveIsTrue(any());
+        verify(contractRepository, times(1)).findContractByEmployeeIdAndActiveIsTrueAndDeletedIsFalse(any());
         verify((BaseService) underTest, times(1)).create(eq(requestedContract.withActive(true)));
 
         assertFalse(contractCaptor.getValue().isActive());
@@ -132,7 +132,7 @@ class ContractServiceTest {
         when(roleRepository.findById(any())).thenReturn(Optional.of(aRole()));
         when(seniorityRepository.findById(any())).thenReturn(Optional.of(aSeniority()));
         when(contractRepository.save(any())).thenReturn(existentContract);
-        when(contractRepository.findContractByEmployeeIdAndActiveIsTrue(any())).thenReturn(Optional.empty());
+        when(contractRepository.findContractByEmployeeIdAndActiveIsTrueAndDeletedIsFalse(any())).thenReturn(Optional.empty());
         when(paymentSettlementService.create(any(), any())).thenReturn(null);
         when(paymentSettlementRepository.findAllByContractIdAndDeletedIsFalse(any())).thenReturn(
                 Collections.emptyList());
@@ -145,7 +145,7 @@ class ContractServiceTest {
 
         verify(employeeRepository, times(1)).findById(eq(requestedContract.employeeId()));
         verify(contractRepository, never()).saveAndFlush(any());
-        verify(contractRepository, times(1)).findContractByEmployeeIdAndActiveIsTrue(any());
+        verify(contractRepository, times(1)).findContractByEmployeeIdAndActiveIsTrueAndDeletedIsFalse(any());
         verify((BaseService) underTest, times(1)).create(eq(requestedContract.withActive(true)));
     }
 
@@ -156,7 +156,7 @@ class ContractServiceTest {
         ContractDto requestedContract = new ContractDto(existentContract);
 
         // when
-        when(contractRepository.findContractByEmployeeIdAndActiveIsTrue(any())).thenThrow(
+        when(contractRepository.findContractByEmployeeIdAndActiveIsTrueAndDeletedIsFalse(any())).thenThrow(
                 new RuntimeException("Test exception thrown!!"));
 
         // then
@@ -182,7 +182,7 @@ class ContractServiceTest {
 
         // when
         when(contractRepository.findById(any())).thenReturn(Optional.of(existentContract));
-        when(contractRepository.findContractByEmployeeIdAndActiveIsTrue(any())).thenReturn(Optional.of(activeContract));
+        when(contractRepository.findContractByEmployeeIdAndActiveIsTrueAndDeletedIsFalse(any())).thenReturn(Optional.of(activeContract));
         when(contractRepository.save(any())).thenReturn(activated);
         when(paymentSettlementRepository.findAllByContractIdAndDeletedIsFalse(any())).thenReturn(
                 Collections.emptyList());
@@ -193,7 +193,7 @@ class ContractServiceTest {
 
         Assertions.assertEquals(expected, actual);
         verify(contractRepository, times(1)).findById(eq(existentContract.getId()));
-        verify(contractRepository, times(1)).findContractByEmployeeIdAndActiveIsTrue(
+        verify(contractRepository, times(1)).findContractByEmployeeIdAndActiveIsTrueAndDeletedIsFalse(
                 existentContract.getEmployee().getId());
         verify(contractRepository, times(1)).saveAndFlush(contractCaptor.capture());
         verify(contractRepository, times(1)).save(contractCaptor.capture());
@@ -230,7 +230,7 @@ class ContractServiceTest {
 
         assertEquals(expected, actual);
         verify(contractRepository, times(1)).findById(eq(existentContract.getId()));
-        verify(contractRepository, times(1)).findContractByEmployeeIdAndActiveIsTrue(
+        verify(contractRepository, times(1)).findContractByEmployeeIdAndActiveIsTrueAndDeletedIsFalse(
                 existentContract.getEmployee().getId());
         verify(contractRepository, times(1)).save(contractCaptor.capture());
         verifyNoMoreInteractions(contractRepository);

--- a/src/test/java/com/entropyteam/entropay/employees/services/ContractServiceTest.java
+++ b/src/test/java/com/entropyteam/entropay/employees/services/ContractServiceTest.java
@@ -155,11 +155,6 @@ class ContractServiceTest {
         // given
         ContractDto requestedContract = new ContractDto(existentContract);
 
-        // when
-        // when(contractRepository.findContractByEmployeeIdAndActiveIsTrueAndDeletedIsFalse(any())).thenThrow(
-        // new RuntimeException("Test exception thrown!!"));
-        // unnecessary stubbing drops an UnnecessaryStubbingException
-
         // then
         assertThrows(RuntimeException.class, () ->
                         contractService.create(new ContractDto(existentContract)),


### PR DESCRIPTION
# Description :pencil:

The contract status now is based on due date

## Link to ticket :link:

https://entropyteam.atlassian.net/browse/EN-72

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? :microscope:

Manual testing.

the following cases were tested:

the following cases were tested:

1. New active contract: when a new valid contract is created it is active

2. New inactive contract: when a new contract has end date before now it is inactive

3. New contract with end date null is active: when a new contract has null end date it is active

4. New contract with start date after now and end date after start date is inactive

5. Inactive last active contract when a new active contract is created: when a new active contract is created the last active contract is set inactive

6. Last active contract stays active when inactive contract is created

7. Last active contract set inactive when new contract with null end date is created
