### PR TITLE
EN-76: Prefill new contract/assignment with active information

### DIFF
--- a/src/main/java/com/entropyteam/entropay/common/BaseService.java
+++ b/src/main/java/com/entropyteam/entropay/common/BaseService.java
@@ -119,7 +119,7 @@ public abstract class BaseService<Entity extends BaseEntity, DTO, Key> implement
 
 
         if(filter.getGetByFieldsFilter().containsKey(SEARCH_TERM_KEY)){
-            String searchInput = filter.getGetByFieldsFilter().get(SEARCH_TERM_KEY).toLowerCase();
+            String searchInput = filter.getGetByFieldsFilter().get(SEARCH_TERM_KEY).toString().toLowerCase();
             ArrayList<Predicate> searchPredicates = new ArrayList<>();
             for(String column: getColumnsForSearch()){
                 Predicate searchContainsColumn = cb.like(cb.lower(root.get(column)), "%"+searchInput+"%");

--- a/src/main/java/com/entropyteam/entropay/common/Filter.java
+++ b/src/main/java/com/entropyteam/entropay/common/Filter.java
@@ -10,12 +10,14 @@ public class Filter {
     private Map<String, List<UUID>> getByIdsFilter;
     private Map<String, String> getByFieldsFilter;
     private Map<String, UUID> getByRelatedFieldsFilter;
+    private Map<String, Boolean> getByBooleanFieldsFilter;
 
     public Filter(Map<String, List<UUID>> getByIdsFilter, Map<String, String> getByFieldsFilter,
-            Map<String, UUID> getByRelatedFieldsFilter) {
+            Map<String, UUID> getByRelatedFieldsFilter, Map<String, Boolean> getByBooleanFieldsFilter) {
         this.getByIdsFilter = getByIdsFilter;
         this.getByFieldsFilter = getByFieldsFilter;
         this.getByRelatedFieldsFilter = getByRelatedFieldsFilter;
+        this.getByBooleanFieldsFilter = getByBooleanFieldsFilter;
     }
 
     public Map<String, List<UUID>> getGetByIdsFilter() {
@@ -40,5 +42,13 @@ public class Filter {
 
     public void setGetByRelatedFieldsFilter(Map<String, UUID> getByRelatedFieldsFilter) {
         this.getByRelatedFieldsFilter = getByRelatedFieldsFilter;
+    }
+
+    public Map<String, Boolean> getGetByBooleanFieldsFilter() {
+        return getByBooleanFieldsFilter;
+    }
+
+    public void setGetByBooleanFieldsFilter(Map<String, Boolean> getByBooleanFieldsFilter) {
+        this.getByBooleanFieldsFilter = getByBooleanFieldsFilter;
     }
 }

--- a/src/main/java/com/entropyteam/entropay/common/Filter.java
+++ b/src/main/java/com/entropyteam/entropay/common/Filter.java
@@ -8,16 +8,14 @@ import java.util.UUID;
 public class Filter {
 
     private Map<String, List<UUID>> getByIdsFilter;
-    private Map<String, String> getByFieldsFilter;
+    private Map<String, Object> getByFieldsFilter;
     private Map<String, UUID> getByRelatedFieldsFilter;
-    private Map<String, Boolean> getByBooleanFieldsFilter;
 
-    public Filter(Map<String, List<UUID>> getByIdsFilter, Map<String, String> getByFieldsFilter,
-            Map<String, UUID> getByRelatedFieldsFilter, Map<String, Boolean> getByBooleanFieldsFilter) {
+    public Filter(Map<String, List<UUID>> getByIdsFilter, Map<String, Object> getByFieldsFilter,
+            Map<String, UUID> getByRelatedFieldsFilter) {
         this.getByIdsFilter = getByIdsFilter;
         this.getByFieldsFilter = getByFieldsFilter;
         this.getByRelatedFieldsFilter = getByRelatedFieldsFilter;
-        this.getByBooleanFieldsFilter = getByBooleanFieldsFilter;
     }
 
     public Map<String, List<UUID>> getGetByIdsFilter() {
@@ -28,11 +26,11 @@ public class Filter {
         this.getByIdsFilter = getByIdsFilter;
     }
 
-    public Map<String, String> getGetByFieldsFilter() {
+    public Map<String, Object> getGetByFieldsFilter() {
         return getByFieldsFilter;
     }
 
-    public void setGetByFieldsFilter(Map<String, String> getByFieldsFilter) {
+    public void setGetByFieldsFilter(Map<String, Object> getByFieldsFilter) {
         this.getByFieldsFilter = getByFieldsFilter;
     }
 
@@ -44,11 +42,4 @@ public class Filter {
         this.getByRelatedFieldsFilter = getByRelatedFieldsFilter;
     }
 
-    public Map<String, Boolean> getGetByBooleanFieldsFilter() {
-        return getByBooleanFieldsFilter;
-    }
-
-    public void setGetByBooleanFieldsFilter(Map<String, Boolean> getByBooleanFieldsFilter) {
-        this.getByBooleanFieldsFilter = getByBooleanFieldsFilter;
-    }
 }

--- a/src/main/java/com/entropyteam/entropay/common/ReactAdminMapper.java
+++ b/src/main/java/com/entropyteam/entropay/common/ReactAdminMapper.java
@@ -1,6 +1,10 @@
 package com.entropyteam.entropay.common;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -37,8 +41,7 @@ public class ReactAdminMapper {
     public Filter buildFilter(ReactAdminParams params, Class entityClass) {
         try {
             Map<String, List<UUID>> getByIdsFilter = new HashMap<>();
-            Map<String, String> getByFieldsFilter = new HashMap<>();
-            Map<String, Boolean> getByBooleanFieldsFilter = new HashMap<>();
+            Map<String, Object> getByFieldsFilter = new HashMap<>();
             Map<String, UUID> getByRelatedFieldsFilter = new HashMap<>();
 
             if (params.getFilter() != null) {
@@ -51,20 +54,15 @@ public class ReactAdminMapper {
                                 ids.stream().map(UUID::fromString).collect(Collectors.toList()));
                     } else if (isEntityField(entityClass, filter.getKey()) || StringUtils.equalsIgnoreCase(filter.getKey(), SEARCH_TERM_KEY)) {
                         // getList filter
-                        if (filter.getKey() == "active") {
-                            getByBooleanFieldsFilter.put(filter.getKey(), true);
-                        } else {
-                            getByFieldsFilter.put(filter.getKey(), filter.getValue().toString());
-                        }
+                        getByFieldsFilter.put(filter.getKey(), filter.getValue());
                     } else {
                         // getManyReference filter
                         String relatedEntity = StringUtils.removeEnd(filter.getKey(), "Id");
                         getByRelatedFieldsFilter.put(relatedEntity, UUID.fromString((String) filter.getValue()));
-
                     }
                 }
             }
-            return new Filter(getByIdsFilter, getByFieldsFilter, getByRelatedFieldsFilter, getByBooleanFieldsFilter);
+            return new Filter(getByIdsFilter, getByFieldsFilter, getByRelatedFieldsFilter);
         } catch (JsonProcessingException e) {
             throw new InvalidRequestParametersException("Bad param on filters");
         }

--- a/src/main/java/com/entropyteam/entropay/common/ReactAdminMapper.java
+++ b/src/main/java/com/entropyteam/entropay/common/ReactAdminMapper.java
@@ -1,10 +1,6 @@
 package com.entropyteam.entropay.common;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -42,6 +38,7 @@ public class ReactAdminMapper {
         try {
             Map<String, List<UUID>> getByIdsFilter = new HashMap<>();
             Map<String, String> getByFieldsFilter = new HashMap<>();
+            Map<String, Boolean> getByBooleanFieldsFilter = new HashMap<>();
             Map<String, UUID> getByRelatedFieldsFilter = new HashMap<>();
 
             if (params.getFilter() != null) {
@@ -54,7 +51,11 @@ public class ReactAdminMapper {
                                 ids.stream().map(UUID::fromString).collect(Collectors.toList()));
                     } else if (isEntityField(entityClass, filter.getKey()) || StringUtils.equalsIgnoreCase(filter.getKey(), SEARCH_TERM_KEY)) {
                         // getList filter
-                        getByFieldsFilter.put(filter.getKey(), (String) filter.getValue());
+                        if (filter.getKey() == "active") {
+                            getByBooleanFieldsFilter.put(filter.getKey(), true);
+                        } else {
+                            getByFieldsFilter.put(filter.getKey(), filter.getValue().toString());
+                        }
                     } else {
                         // getManyReference filter
                         String relatedEntity = StringUtils.removeEnd(filter.getKey(), "Id");
@@ -63,7 +64,7 @@ public class ReactAdminMapper {
                     }
                 }
             }
-            return new Filter(getByIdsFilter, getByFieldsFilter, getByRelatedFieldsFilter);
+            return new Filter(getByIdsFilter, getByFieldsFilter, getByRelatedFieldsFilter, getByBooleanFieldsFilter);
         } catch (JsonProcessingException e) {
             throw new InvalidRequestParametersException("Bad param on filters");
         }

--- a/src/main/java/com/entropyteam/entropay/employees/controllers/ContractController.java
+++ b/src/main/java/com/entropyteam/entropay/employees/controllers/ContractController.java
@@ -1,7 +1,5 @@
 package com.entropyteam.entropay.employees.controllers;
 
-import java.io.Console;
-import java.sql.SQLOutput;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -49,11 +47,6 @@ public class ContractController extends BaseController<ContractDto, UUID> {
         return ResponseEntity.ok().header(BaseController.X_TOTAL_COUNT, String.valueOf(Currency.values().length))
                 .body(Currency.values());
 
-    }
-
-    @GetMapping("/{id}/active")
-    public ResponseEntity<ContractDto> getActiveContract(@PathVariable UUID id) {
-        return ResponseEntity.ok(contractService.getActiveContract(id));
     }
 
 }

--- a/src/main/java/com/entropyteam/entropay/employees/controllers/ContractController.java
+++ b/src/main/java/com/entropyteam/entropay/employees/controllers/ContractController.java
@@ -1,5 +1,7 @@
 package com.entropyteam.entropay.employees.controllers;
 
+import java.io.Console;
+import java.sql.SQLOutput;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -47,6 +49,11 @@ public class ContractController extends BaseController<ContractDto, UUID> {
         return ResponseEntity.ok().header(BaseController.X_TOTAL_COUNT, String.valueOf(Currency.values().length))
                 .body(Currency.values());
 
+    }
+
+    @GetMapping("/{id}/active")
+    public ResponseEntity<ContractDto> getActiveContract(@PathVariable UUID id) {
+        return ResponseEntity.ok(contractService.getActiveContract(id));
     }
 
 }

--- a/src/main/java/com/entropyteam/entropay/employees/dtos/EmployeeDto.java
+++ b/src/main/java/com/entropyteam/entropay/employees/dtos/EmployeeDto.java
@@ -50,7 +50,7 @@ public record EmployeeDto(UUID id,
                           String project,
                           String client,
                           String role,
-                          AssignmentDto lastAssignment,
+                          UUID lastAssignmentId,
                           @JsonFormat(pattern = "yyyy-MM-dd") LocalDate startDate) {
 
     public EmployeeDto(Employee employee, List<PaymentInformation> paymentInformationList) {
@@ -81,7 +81,7 @@ public record EmployeeDto(UUID id,
                 lastAssignment != null ? lastAssignment.getProject().getName() : "-",
                 lastAssignment != null ? lastAssignment.getProject().getClient().getName() : "-",
                 lastAssignment != null ? lastAssignment.getRole().getName() : "-",
-                lastAssignment != null? new AssignmentDto(lastAssignment): null,
+                lastAssignment != null? lastAssignment.getId() : null,
                 firstContract != null ? firstContract.getStartDate() : null);
     }
 }

--- a/src/main/java/com/entropyteam/entropay/employees/dtos/EmployeeDto.java
+++ b/src/main/java/com/entropyteam/entropay/employees/dtos/EmployeeDto.java
@@ -50,6 +50,7 @@ public record EmployeeDto(UUID id,
                           String project,
                           String client,
                           String role,
+                          AssignmentDto lastAssignment,
                           @JsonFormat(pattern = "yyyy-MM-dd") LocalDate startDate) {
 
     public EmployeeDto(Employee employee, List<PaymentInformation> paymentInformationList) {
@@ -62,7 +63,7 @@ public record EmployeeDto(UUID id,
                 employee.getHealthInsurance(), paymentInformationList.stream().map(PaymentInformationDto::new).toList(),
                 employee.getTechnologies().stream().map(BaseEntity::getId).collect(Collectors.toList()),
                 employee.getLabourEmail(), employee.getBirthDate(), employee.getCreatedAt(), employee.getModifiedAt(),
-                employee.isDeleted(), null, null, null, null);
+                employee.isDeleted(), null, null, null, null, null);
     }
 
     public EmployeeDto(Employee employee, List<PaymentInformation> paymentInformationList, Assignment lastAssignment,
@@ -80,6 +81,7 @@ public record EmployeeDto(UUID id,
                 lastAssignment != null ? lastAssignment.getProject().getName() : "-",
                 lastAssignment != null ? lastAssignment.getProject().getClient().getName() : "-",
                 lastAssignment != null ? lastAssignment.getRole().getName() : "-",
+                lastAssignment != null? new AssignmentDto(lastAssignment): null,
                 firstContract != null ? firstContract.getStartDate() : null);
     }
 }

--- a/src/main/java/com/entropyteam/entropay/employees/services/ContractService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/services/ContractService.java
@@ -8,7 +8,13 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import com.entropyteam.entropay.employees.models.*;
+import com.entropyteam.entropay.employees.models.Company;
+import com.entropyteam.entropay.employees.models.Contract;
+import com.entropyteam.entropay.employees.models.Employee;
+import com.entropyteam.entropay.employees.models.PaymentSettlement;
+import com.entropyteam.entropay.employees.models.Role;
+import com.entropyteam.entropay.employees.models.Seniority;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/entropyteam/entropay/employees/services/ContractService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/services/ContractService.java
@@ -2,7 +2,10 @@ package com.entropyteam.entropay.employees.services;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.*;
+import java.util.Optional;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import com.entropyteam.entropay.employees.models.*;

--- a/src/main/java/com/entropyteam/entropay/employees/services/ContractService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/services/ContractService.java
@@ -144,4 +144,10 @@ public class ContractService extends BaseService<Contract, ContractDto, UUID> {
         }
         return contractToCheck;
     }
+
+    @Transactional
+    public ContractDto getActiveContract(UUID id) {
+        Contract contractActiveToReturn = contractRepository.findContractByEmployeeIdAndActiveIsTrueAndDeletedIsFalse(id).orElse(new Contract());
+        return new ContractDto(contractActiveToReturn);
+    }
 }

--- a/src/main/java/com/entropyteam/entropay/employees/services/ContractService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/services/ContractService.java
@@ -145,9 +145,4 @@ public class ContractService extends BaseService<Contract, ContractDto, UUID> {
         return contractToCheck;
     }
 
-    @Transactional
-    public ContractDto getActiveContract(UUID id) {
-        Contract contractActiveToReturn = contractRepository.findContractByEmployeeIdAndActiveIsTrueAndDeletedIsFalse(id).orElse(new Contract());
-        return new ContractDto(contractActiveToReturn);
-    }
 }


### PR DESCRIPTION
# Description :pencil:

When a new contract/employee is created from employees profile, the latest active information is prefill in the form.

## Link to ticket :link:

https://entropyteam.atlassian.net/browse/EN-76

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? :microscope:

Manual testing:

-New assignment from employees prefill the assignment with null end date.
-New assignment from an employee without assignment only prefill the employee's name
-New contract from employees prefill the contract with active status.
-New contract from an employee without contracts only prefill the employee's name

