### PR TITLE
EN-93: Add active field to Assignment entity

### DIFF
--- a/src/main/java/com/entropyteam/entropay/employees/dtos/AssignmentDto.java
+++ b/src/main/java/com/entropyteam/entropay/employees/dtos/AssignmentDto.java
@@ -41,8 +41,8 @@ public record AssignmentDto(UUID id,
                 assignment.getRole().getId(), assignment.getSeniority().getId(), assignment.getHoursPerMonth(),
                 assignment.getLabourHours(), assignment.getBillableRate(),
                 assignment.getCurrency() != null ? assignment.getCurrency().name() : null,
-                assignment.getStartDate(), assignment.getEndDate(), assignment.isDeleted(), assignment.getCreatedAt(),
-                assignment.getModifiedAt()
+                assignment.getStartDate(), assignment.getEndDate(), assignment.isDeleted(),
+                assignment.getModifiedAt(), assignment.getCreatedAt()
         );
     }
 

--- a/src/main/java/com/entropyteam/entropay/employees/models/Assignment.java
+++ b/src/main/java/com/entropyteam/entropay/employees/models/Assignment.java
@@ -49,7 +49,8 @@ public class Assignment extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "currency")
     private Currency currency;
-
+    @Column
+    private boolean active;
     public Assignment() {
     }
 
@@ -141,4 +142,13 @@ public class Assignment extends BaseEntity {
     public void setCurrency(Currency currency) {
         this.currency = currency;
     }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+
 }

--- a/src/main/java/com/entropyteam/entropay/employees/services/AssignmentService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/services/AssignmentService.java
@@ -67,6 +67,7 @@ public class AssignmentService extends BaseService<Assignment, AssignmentDto, UU
         assignment.setRole(role);
         assignment.setSeniority(seniority);
         assignment.setProject(project);
+        assignment.setActive(true);
 
         return assignment;
     }

--- a/src/main/resources/db/migration/V28.0__DDL_update_assignment_table_update_active.sql
+++ b/src/main/resources/db/migration/V28.0__DDL_update_assignment_table_update_active.sql
@@ -1,0 +1,2 @@
+ALTER TABLE assignment
+    ADD active BOOLEAN NOT NULL DEFAULT true;


### PR DESCRIPTION
# Description :pencil:

Added the active value to the Assignment entity, currently by default, all assignments are set to the 'active' value as true.

## Link to ticket :link:

https://entropyteam.atlassian.net/browse/EN-93

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? :microscope:

Successfully ran the command mvn flyway:migrate
![image](https://github.com/entropy-code/entropay-employees/assets/96883646/d6b58b6b-610b-4cbc-b1a5-8cd035fdb3f6)


This is how the Assignment entity looks with its active value set to true
![image](https://github.com/entropy-code/entropay-employees/assets/96883646/056e029a-a7f1-408e-bcca-610c03450308)

