### PR TITLE
EN-95:  Set active field to Assignment entity

### DIFF
--- a/src/main/java/com/entropyteam/entropay/employees/dtos/AssignmentDto.java
+++ b/src/main/java/com/entropyteam/entropay/employees/dtos/AssignmentDto.java
@@ -28,6 +28,7 @@ public record AssignmentDto(UUID id,
                             @JsonFormat(pattern = "yyyy-MM-dd")
                             LocalDate endDate,
                             boolean deleted,
+                            boolean active,
                             @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
                             LocalDateTime createdAt,
                             @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
@@ -42,6 +43,7 @@ public record AssignmentDto(UUID id,
                 assignment.getLabourHours(), assignment.getBillableRate(),
                 assignment.getCurrency() != null ? assignment.getCurrency().name() : null,
                 assignment.getStartDate(), assignment.getEndDate(), assignment.isDeleted(),
+                assignment.isActive(),
                 assignment.getModifiedAt(), assignment.getCreatedAt()
         );
     }

--- a/src/main/java/com/entropyteam/entropay/employees/repositories/AssignmentRepository.java
+++ b/src/main/java/com/entropyteam/entropay/employees/repositories/AssignmentRepository.java
@@ -1,6 +1,7 @@
 package com.entropyteam.entropay.employees.repositories;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import com.entropyteam.entropay.common.BaseRepository;
 import com.entropyteam.entropay.employees.models.Assignment;
@@ -8,4 +9,5 @@ import com.entropyteam.entropay.employees.models.Assignment;
 public interface AssignmentRepository extends BaseRepository<Assignment, UUID> {
 
     List<Assignment> findAssignmentByEmployee_IdAndDeletedIsFalse(UUID employee_id);
+    Optional<Assignment> findAssignmentByEmployeeIdAndActiveIsTrueAndDeletedIsFalse(UUID employee_id);
 }

--- a/src/main/java/com/entropyteam/entropay/employees/services/AssignmentService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/services/AssignmentService.java
@@ -4,7 +4,11 @@ import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
 
-import com.entropyteam.entropay.employees.models.*;
+import com.entropyteam.entropay.employees.models.Assignment;
+import com.entropyteam.entropay.employees.models.Employee;
+import com.entropyteam.entropay.employees.models.Project;
+import com.entropyteam.entropay.employees.models.Role;
+import com.entropyteam.entropay.employees.models.Seniority;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import com.entropyteam.entropay.auth.SecureObjectService;


### PR DESCRIPTION
# Description :pencil:

The ability has been added for Assignments, when created, to set "active" to true based on the entered date. If there was a previous Assignment, it will automatically set it to "active" false. This logic also applies to the update.

## Link to ticket :link:

https://entropyteam.atlassian.net/browse/EN-95

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? :microscope:


Here is the incorporated logic for dates, where the most important conditions are:

The end date is null (ongoing contract).
The end date is after the current date (ongoing contract).
The start date is before the current date (active contract).
The start date is equal to the current date (contract starting today).

![image](https://github.com/entropy-code/entropay-employees/assets/96883646/e534a584-6199-4c20-bb45-8c163cc97179)

Here I show how it was tested by creating an Assignment, the first one was set to true, and upon creating the newest one, it was also set to true.
![image](https://github.com/entropy-code/entropay-employees/assets/96883646/6f8eccb2-0c27-43eb-8b9a-b405c168a9ad)


