### PR TITLE
EN-96: personal info updates

### DIFF
--- a/src/main/java/com/entropyteam/entropay/employees/dtos/EmployeeDto.java
+++ b/src/main/java/com/entropyteam/entropay/employees/dtos/EmployeeDto.java
@@ -15,46 +15,39 @@ import com.entropyteam.entropay.employees.models.PaymentInformation;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
 public record EmployeeDto(UUID id,
-                          @NotNull(message = "Internal ID is mandatory")
-                          String internalId,
-                          @NotNull(message = "First Name is mandatory")
-                          String firstName,
-                          @NotNull(message = "Last Name is mandatory")
-                          String lastName,
-                          @Email
-                          @NotNull(message = "Email is mandatory")
-                          String personalEmail,
-                          String phoneNumber,
-                          String mobileNumber,
-                          String address,
-                          String city,
-                          String state,
-                          String zip,
-                          String country,
-                          @NotNull(message = "Personal Number is mandatory")
-                          String personalNumber,
-                          String taxId,
-                          String emergencyContactFullName,
-                          String emergencyContactPhone,
-                          List<UUID> profile,
-                          String notes,
-                          String healthInsurance,
-                          List<PaymentInformationDto> paymentInformation,
-                          List<UUID> technologies,
-                          @Email
-                          String labourEmail,
-                          @JsonFormat(pattern = "yyyy-MM-dd") LocalDate birthDate,
-                          @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt,
-                          @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime modifiedAt,
-                          boolean deleted,
-                          String project,
-                          String client,
-                          String role,
-                          UUID lastAssignmentId,
-                          @JsonFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
-                          @NotNull(message = "Active state is mandatory")
-                          boolean active,
-                          Integer availableDays) {
+        @NotNull(message = "Internal ID is mandatory") String internalId,
+        @NotNull(message = "First Name is mandatory") String firstName,
+        @NotNull(message = "Last Name is mandatory") String lastName,
+        @Email @NotNull(message = "Email is mandatory") String personalEmail,
+        String phoneNumber,
+        String mobileNumber,
+        String address,
+        String city,
+        String state,
+        String zip,
+        String country,
+        @NotNull(message = "Personal Number is mandatory") String personalNumber,
+        String taxId,
+        String emergencyContactFullName,
+        String emergencyContactPhone,
+        List<UUID> profile,
+        String notes,
+        String healthInsurance,
+        List<PaymentInformationDto> paymentInformation,
+        List<UUID> technologies,
+        @Email String labourEmail,
+        @JsonFormat(pattern = "yyyy-MM-dd") LocalDate birthDate,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime modifiedAt,
+        boolean deleted,
+        String project,
+        String client,
+        String role,
+        UUID lastAssignmentId,
+        @JsonFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
+        @JsonFormat(pattern = "yyyy-MM-dd") LocalDate endDate,
+        @NotNull(message = "Active state is mandatory") boolean active,
+        Integer availableDays) {
 
     public EmployeeDto(Employee employee, List<PaymentInformation> paymentInformationList) {
         this(employee.getId(), employee.getInternalId(), employee.getFirstName(), employee.getLastName(),
@@ -66,11 +59,11 @@ public record EmployeeDto(UUID id,
                 employee.getHealthInsurance(), paymentInformationList.stream().map(PaymentInformationDto::new).toList(),
                 employee.getTechnologies().stream().map(BaseEntity::getId).collect(Collectors.toList()),
                 employee.getLabourEmail(), employee.getBirthDate(), employee.getCreatedAt(), employee.getModifiedAt(),
-                employee.isDeleted(), null, null, null, null, null, employee.isActive(), null);
+                employee.isDeleted(), null, null, null, null, null, null, employee.isActive(), null);
     }
 
     public EmployeeDto(Employee employee, List<PaymentInformation> paymentInformationList, Assignment lastAssignment,
-            Contract firstContract, Integer availableDays) {
+            Contract firstContract, Integer availableDays, Contract lastContract) {
         this(employee.getId(), employee.getInternalId(), employee.getFirstName(), employee.getLastName(),
                 employee.getPersonalEmail(), employee.getPhoneNumber(), employee.getMobileNumber(),
                 employee.getAddress(), employee.getCity(), employee.getState(), employee.getZip(),
@@ -84,8 +77,10 @@ public record EmployeeDto(UUID id,
                 lastAssignment != null ? lastAssignment.getProject().getName() : "-",
                 lastAssignment != null ? lastAssignment.getProject().getClient().getName() : "-",
                 lastAssignment != null ? lastAssignment.getRole().getName() : "-",
-                lastAssignment != null? lastAssignment.getId() : null,
-                firstContract != null ? firstContract.getStartDate() : null, employee.isActive(),
+                lastAssignment != null ? lastAssignment.getId() : null,
+                firstContract != null ? firstContract.getStartDate() : null,
+                lastContract != null ? lastContract.getEndDate() : null,
+                employee.isActive(),
                 availableDays != null ? availableDays : 0);
     }
 }

--- a/src/main/java/com/entropyteam/entropay/employees/services/EmployeeService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/services/EmployeeService.java
@@ -69,17 +69,19 @@ public class EmployeeService extends BaseService<Employee, EmployeeDto, UUID> {
     protected EmployeeDto toDTO(Employee entity) {
         List<PaymentInformation> paymentInformationList =
                 paymentRepository.findAllByEmployeeIdAndDeletedIsFalse(entity.getId());
-        List<Assignment> assignments =
-                assignmentRepository.findAssignmentByEmployee_IdAndDeletedIsFalse(entity.getId());
+        Optional<Assignment> assignments =
+                assignmentRepository.findAssignmentByEmployeeIdAndActiveIsTrueAndDeletedIsFalse(entity.getId());
         Optional<Assignment> lastAssignment = assignments.stream().filter(a -> a.getEndDate() == null).findFirst();
-        if (lastAssignment.isEmpty()) {
-            lastAssignment = assignments.stream().max(Comparator.comparing(Assignment::getEndDate));
-        }
 
         List<Contract> contracts = contractRepository.findAllByEmployeeIdAndDeletedIsFalse(entity.getId());
         Optional<Contract> firstContract = contracts.stream().min(Comparator.comparing(Contract::getStartDate));
         Integer availableDays = vacationRepository.getAvailableDays(entity.getId());
-        return new EmployeeDto(entity, paymentInformationList, lastAssignment.orElse(null), firstContract.orElse(null), availableDays);
+        Optional<Contract> activeContract =
+                contractRepository.findContractByEmployeeIdAndActiveIsTrueAndDeletedIsFalse(entity.getId());
+        Optional<Contract> lastContract =
+                activeContract.stream().min(Comparator.comparing(Contract::getEndDate));
+
+        return new EmployeeDto(entity, paymentInformationList, lastAssignment.orElse(null), firstContract.orElse(null), availableDays,lastContract.orElse(null));
     }
 
     @Override


### PR DESCRIPTION
# Description :pencil:

The ability for the employee to return his endDate according to his last contract has been added. This feature always requires an active contract and ensures that it is not deleted. Additionally, the method to search for true assignments has also been improved in the service.

## Link to ticket :link:

https://entropyteam.atlassian.net/browse/EN-96

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? :microscope:

It also takes into account the possibility of endDate being null
![image](https://github.com/entropy-code/entropay-employees/assets/96883646/dbc871fe-194b-496f-8ead-4442f76caa15)
