### PR TITLE
En 94 - Cascade on employee deletion

### DIFF
--- a/src/main/java/com/entropyteam/entropay/employees/services/EmployeeService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/services/EmployeeService.java
@@ -1,5 +1,6 @@
 package com.entropyteam.entropay.employees.services;
 
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -108,14 +109,65 @@ public class EmployeeService extends BaseService<Employee, EmployeeDto, UUID> {
     public EmployeeDto update(UUID employeeId, EmployeeDto employeeDto) {
         Employee entityToUpdate = toEntity(employeeDto);
         entityToUpdate.setId(employeeId);
+
+
+        if (shouldDeactivateEmployee(employeeId, entityToUpdate)) {
+
+            List<Contract> employeeContracts = contractRepository.findAllByEmployeeIdAndDeletedIsFalse(employeeId);
+            List<Assignment> employeeAssignments = assignmentRepository.findAssignmentByEmployee_IdAndDeletedIsFalse(employeeId);
+
+            employeeContracts.forEach(contract -> {
+                contract.setActive(false);
+                contract.setEndDate(LocalDate.now());
+            });
+            contractRepository.saveAll(employeeContracts);
+
+            employeeAssignments.forEach(assignment -> {
+                assignment.setActive(false);
+                assignment.setEndDate(LocalDate.now());
+            });
+            assignmentRepository.saveAll(employeeAssignments);
+        }
+
         Employee savedEntity = getRepository().save(entityToUpdate);
         paymentInformationService.updatePaymentsInformation(employeeDto.paymentInformation(), savedEntity);
         return toDTO(savedEntity);
     }
 
     @Override
+    @Transactional
+    public EmployeeDto delete(UUID employeeId) {
+        Employee employee = getRepository().findById(employeeId).orElseThrow();
+        employee.setDeleted(true);
+        employee.setActive(false);
+        List<Contract> employeeContracts = contractRepository.findAllByEmployeeIdAndDeletedIsFalse(employeeId);
+        List<Assignment> employeeAssignment = assignmentRepository.findAssignmentByEmployee_IdAndDeletedIsFalse(employeeId);
+
+        employeeContracts.forEach(contract -> {
+                    contract.setDeleted(true);
+                    contract.setActive(false);
+                    contract.setEndDate(LocalDate.now());
+                });
+        contractRepository.saveAll(employeeContracts);
+
+        employeeAssignment.forEach(assignment -> {
+                    assignment.setDeleted(true);
+                    assignment.setActive(false);
+                    assignment.setEndDate(LocalDate.now());
+                });
+        assignmentRepository.saveAll(employeeAssignment);
+
+        return toDTO(employee);
+    }
+
+    @Override
     public List<String> getColumnsForSearch() {
         return Arrays.asList("firstName", "lastName", "internalId");
+    }
+
+    private boolean shouldDeactivateEmployee(UUID employeeId, Employee entityToUpdate) {
+        Employee existingEmployee = getRepository().getById(employeeId);
+        return existingEmployee.isActive() && !entityToUpdate.isActive();
     }
 
 }


### PR DESCRIPTION
# Description :pencil:

When an employee is deleted, his contracts and assignments must also be marked as deleted, and the last modified file would be updated.
The same process workflow when an employee is deactivated, both his contracts and assignments would be deactivated.

## Link to ticket :link:

https://entropyteam.atlassian.net/browse/EN-94

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? :microscope:

Manual testing through the UI