### PR TITLE
EN-107: Fix cron expression in vacation job

### DIFF
--- a/src/main/java/com/entropyteam/entropay/employees/jobs/VacationJob.java
+++ b/src/main/java/com/entropyteam/entropay/employees/jobs/VacationJob.java
@@ -47,7 +47,7 @@ public class VacationJob {
     }
 
     //Job to execute in October and January
-    @Scheduled(cron = "0 0 8 1 1,10 ?")
+    @Scheduled(cron = "0 0 8 ? 1,10 MON#1")
     @Transactional
     public void setEmployeeVacations() throws IOException {
         Map<String, Integer> summary = findEmployeeVacations();


### PR DESCRIPTION
# Description :pencil:

In order to fix the job scheduler, the cron expression was update to run on first monday of January and October of every year.

## Link to ticket :link:

https://entropyteam.atlassian.net/browse/EN-107

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Next schedules dates
![image](https://github.com/entropy-code/entropay-employees/assets/70980835/b91783bc-aeda-4f1b-bdc0-4cad5bce4892)
