### PR TITLE
EN-122: End date not being displayed in profile

### DIFF
--- a/src/main/java/com/entropyteam/entropay/employees/services/EmployeeService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/services/EmployeeService.java
@@ -82,12 +82,13 @@ public class EmployeeService extends BaseService<Employee, EmployeeDto, UUID> {
         List<Contract> contracts = contractRepository.findAllByEmployeeIdAndDeletedIsFalse(entity.getId());
         Optional<Contract> firstContract = contracts.stream().min(Comparator.comparing(Contract::getStartDate));
         Integer availableDays = vacationRepository.getAvailableDays(entity.getId());
-        Optional<Contract> activeContract =
-                contractRepository.findContractByEmployeeIdAndActiveIsTrueAndDeletedIsFalse(entity.getId());
         Optional<Contract> latestContract =
-                contracts.stream().max(Comparator.comparing(Contract::getStartDate));
+                contractRepository.findContractByEmployeeIdAndActiveIsTrueAndDeletedIsFalse(entity.getId());
+        if(latestContract.isEmpty()) {
+            latestContract = contracts.stream().max(Comparator.comparing(Contract::getStartDate));
+        }
         LocalDate nearestPto = ptoRepository.findNearestPto(entity.getId());
-        return new EmployeeDto(entity, paymentInformationList, assignment.orElse(null), firstContract.orElse(null), availableDays, activeContract.orElse(latestContract.orElse(null)), nearestPto);
+        return new EmployeeDto(entity, paymentInformationList, assignment.orElse(null), firstContract.orElse(null), availableDays, latestContract.orElse(null), nearestPto);
     }
 
     @Override

--- a/src/main/java/com/entropyteam/entropay/employees/services/EmployeeService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/services/EmployeeService.java
@@ -84,8 +84,10 @@ public class EmployeeService extends BaseService<Employee, EmployeeDto, UUID> {
         Integer availableDays = vacationRepository.getAvailableDays(entity.getId());
         Optional<Contract> activeContract =
                 contractRepository.findContractByEmployeeIdAndActiveIsTrueAndDeletedIsFalse(entity.getId());
+        Optional<Contract> latestContract =
+                contracts.stream().max(Comparator.comparing(Contract::getStartDate));
         LocalDate nearestPto = ptoRepository.findNearestPto(entity.getId());
-        return new EmployeeDto(entity, paymentInformationList, assignment.orElse(null), firstContract.orElse(null), availableDays, activeContract.orElse(null), nearestPto);
+        return new EmployeeDto(entity, paymentInformationList, assignment.orElse(null), firstContract.orElse(null), availableDays, activeContract.orElse(latestContract.orElse(null)), nearestPto);
     }
 
     @Override


### PR DESCRIPTION
# Description :pencil:

Fixed end date not being displayed in profile when there's no active contract, now shows the end date of the latest contract

## Link to ticket :link:

https://entropyteam.atlassian.net/browse/EN-122

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? :microscope:

![image](https://github.com/entropy-code/entropay-employees/assets/89614950/c67b1f5f-fd2f-4639-824c-c26ee2c0610f)
