### PR TITLE
EN-132: Fixed vacation credit set to right year

### DIFF
--- a/src/main/java/com/entropyteam/entropay/employees/jobs/VacationJob.java
+++ b/src/main/java/com/entropyteam/entropay/employees/jobs/VacationJob.java
@@ -65,7 +65,7 @@ public class VacationJob {
 
         LocalDate currentDate = LocalDate.now();
         int currentYear = currentDate.getYear();
-        String vacationYearToAdd = currentDate.getMonthValue() == 10 ? String.valueOf(currentYear + 1) : String.valueOf(currentYear);
+        String vacationYearToAdd = currentDate.getMonthValue() == 10 ? String.valueOf(currentYear) : String.valueOf(currentYear - 1);
 
         List<Holiday> holidaysInPeriod = holidayRepository.findAllByDeletedIsFalse();
         List<Contract> contractsList = contractRepository.findAllByDeletedIsFalse();


### PR DESCRIPTION
# Description :pencil:
Fixed vacations credit not being added to the correct year
## Link to ticket :link:

https://entropyteam.atlassian.net/browse/EN-

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? :microscope:
