### PR TITLE
EN-150 20 days vacation credit for 5 years old employees

### DIFF
--- a/src/main/java/com/entropyteam/entropay/employees/services/EmployeeService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/services/EmployeeService.java
@@ -206,9 +206,7 @@ public class EmployeeService extends BaseService<Employee, EmployeeDto, UUID> {
         if (activeContract.isPresent() && firstContract.isPresent()) {
             LocalDate startDate = firstContract.get().getStartDate();
             if (currentDate.getMonthValue() == Month.OCTOBER.getValue() && startDate.isBefore(LocalDate.of(currentDate.getYear(), Month.JULY, 1))) {
-                int yearDiff = startDate.until(currentDate).getYears();
-                int vacationDays = activeContract.get().getSeniority().getVacationDays();
-                return yearDiff >= 2 ? 15 : vacationDays;
+                return vacationsDayPerSeniority(startDate, currentDate, activeContract);
             } else if (currentDate.getMonthValue() == Month.JANUARY.getValue()) {
                 String seniorityName = activeContract.get().getSeniority().getName();
                 return vacationDaysPerWorkDay(holidaysInPeriod, currentDate, startDate, seniorityName);
@@ -272,5 +270,10 @@ public class EmployeeService extends BaseService<Employee, EmployeeDto, UUID> {
             timeSinceStart.append("0 months");
         }
         return timeSinceStart.toString();
+    }
+
+    private int vacationsDayPerSeniority (LocalDate startDate, LocalDate currentDate, Optional <Contract> activeContract){
+        int yearDiff = startDate.until(currentDate).getYears();
+        return yearDiff >= 5 ? 20 : (yearDiff >= 2 ? 15 : activeContract.get().getSeniority().getVacationDays());
     }
 }

--- a/src/test/java/com/entropyteam/entropay/employees/services/EmployeeServiceTest.java
+++ b/src/test/java/com/entropyteam/entropay/employees/services/EmployeeServiceTest.java
@@ -262,4 +262,37 @@ public class EmployeeServiceTest {
 
     }
 
+    @DisplayName("Default vacation days to employees with 5 years")
+    @Test
+    void applyFiveYearsEmployeeDefaultVacationDays() {
+        Employee oldEmployee = TestUtils.buildEmployee();
+        oldEmployee.setId(UUID.randomUUID());
+
+        Contract activeContract = new Contract();
+        activeContract.setActive(true);
+
+        Seniority seniority = new Seniority();
+        seniority.setId(UUID.randomUUID());
+        seniority.setName("junior");
+        seniority.setVacationDays(15);
+
+        activeContract.setSeniority(seniority);
+        activeContract.setStartDate(LocalDate.of(2018, 07, 29));
+        activeContract.setEmployee(oldEmployee);
+
+        LocalDate currentDate = LocalDate.of(2023, 10, 1);
+
+        List<Contract> employeeContractList = new ArrayList<>();
+        employeeContractList.add(activeContract);
+
+        //when
+        when(vacationRepository.existsVacationByEmployeeIdAndDeletedIsFalseAndYearIsLike(oldEmployee.getId(), currentYear)).thenReturn(false);
+
+        //then
+        int response = employeeService.applyVacationRuleToEmployee(oldEmployee, currentYear, employeeContractList, currentDate, holidaysList);
+
+        //verify
+        assertEquals(response, 20);
+
+    }
 }


### PR DESCRIPTION
# Description :pencil:

This change adds new vacation rule for 5 years old Employees

## Link to ticket :link:

https://entropyteam.atlassian.net/browse/EN-150

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? :microscope:
Tested through UI with "vacations/set-vacations" endpoint with three employees with different ages, simulating both October 1st and current date execution.

<img width="697" alt="Screenshot 2024-01-10 at 09 19 52" src="https://github.com/entropy-code/entropay-employees/assets/85446214/3e302c95-163d-40a1-ae4c-71298e793432">

![Screenshot 2024-01-10 at 09 20 56](https://github.com/entropy-code/entropay-employees/assets/85446214/a37fa8ce-be8d-4b8e-bb40-d8840fcac30c)

![Screenshot 2024-01-10 at 10 00 47](https://github.com/entropy-code/entropay-employees/assets/85446214/4e8b93d5-bd35-40bf-9d0c-409030758f5f)

