### PR TITLE
EN-141 Filter PTOs by year

### DIFF
--- a/src/main/java/com/entropyteam/entropay/employees/controllers/PtoController.java
+++ b/src/main/java/com/entropyteam/entropay/employees/controllers/PtoController.java
@@ -6,7 +6,7 @@ import static com.entropyteam.entropay.auth.AuthConstants.ROLE_MANAGER_HR;
 import static com.entropyteam.entropay.auth.AuthConstants.ROLE_HR_DIRECTOR;
 
 
-import java.util.UUID;
+import java.util.*;
 
 import com.entropyteam.entropay.employees.services.PtoService;
 import org.springframework.http.MediaType;
@@ -15,11 +15,7 @@ import org.springframework.security.access.annotation.Secured;
 import com.entropyteam.entropay.common.BaseController;
 import com.entropyteam.entropay.common.CrudService;
 import com.entropyteam.entropay.employees.dtos.PtoDto;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @CrossOrigin
@@ -33,6 +29,14 @@ public class PtoController extends BaseController<PtoDto, UUID> {
         super(crudService);
         this.ptoService = ptoService;
     }
+
+    @GetMapping("/years")
+    public ResponseEntity<List<Map<String, Integer>>> getPtosYears() {
+        List<Map<String, Integer>> ptosYears = ptoService.getPtosYears();
+        return ResponseEntity.ok().header(BaseController.X_TOTAL_COUNT, String.valueOf(ptosYears.size()))
+                .body(ptosYears);
+    }
+
 
     @PostMapping("/{id}/cancel")
     @Secured({ROLE_MANAGER_HR, ROLE_ADMIN, ROLE_DEVELOPMENT, ROLE_HR_DIRECTOR})

--- a/src/main/java/com/entropyteam/entropay/employees/repositories/PtoRepository.java
+++ b/src/main/java/com/entropyteam/entropay/employees/repositories/PtoRepository.java
@@ -1,9 +1,10 @@
 package com.entropyteam.entropay.employees.repositories;
 
 import java.time.LocalDate;
-import java.util.UUID;
+import java.util.*;
+
 import com.entropyteam.entropay.common.BaseRepository;
-import com.entropyteam.entropay.employees.models.Pto;
+import com.entropyteam.entropay.employees.models.*;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -14,4 +15,8 @@ public interface PtoRepository extends BaseRepository<Pto, UUID> {
             "ORDER BY ABS(EXTRACT(EPOCH FROM (start_date - CURRENT_TIMESTAMP))) " +
             "LIMIT 1", nativeQuery = true)
     LocalDate findNearestPto(@Param("employeeId") UUID employeeId);
+
+    @Query(value = "SELECT DISTINCT extract('Year' FROM start_date) AS year FROM pto WHERE deleted=false "
+            + " ORDER BY year ASC", nativeQuery = true)
+    List<Integer> getPtosYears();
 }

--- a/src/main/java/com/entropyteam/entropay/employees/services/PtoService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/services/PtoService.java
@@ -3,9 +3,8 @@ package com.entropyteam.entropay.employees.services;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
-import java.util.List;
-import java.util.Objects;
-import java.util.UUID;
+import java.util.*;
+import java.util.stream.*;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -204,5 +203,22 @@ public class PtoService extends BaseService<Pto, PtoDto, UUID> {
         googleService.deleteGoogleCalendarEvent(id.toString());
         Pto savedEntity = getRepository().save(pto);
         return toDTO(savedEntity);
+    }
+
+    public List<Map<String, Integer>> getPtosYears() {
+        List<Integer> years = ptoRepository.getPtosYears();
+
+        return years.stream()
+                .map(year -> {
+                    Map<String, Integer> yearMap = new HashMap<>();
+                    yearMap.put("id", year);
+                    yearMap.put("year", year);
+                    return yearMap;
+                })
+                .collect(Collectors.toList());
+    }
+    @Override
+    public List<String> getDateColumnsForSearch() {
+        return List.of("startDate", "endDate");
     }
 }


### PR DESCRIPTION
# Description :pencil:

This PR adds the possibility to filter PTOs by year considering start date and end date

## Link to ticket :link:

https://entropyteam.atlassian.net/browse/EN-141

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? :microscope:

Through the UI by creating Ptos and filtering
<img width="1430" alt="Screenshot 2024-01-12 at 18 13 53" src="https://github.com/entropy-code/entropay-admin-ui/assets/85446214/f1d92789-87f6-46d3-8538-fa9b9a1a6b36">
<img width="1429" alt="Screenshot 2024-01-12 at 18 14 05" src="https://github.com/entropy-code/entropay-admin-ui/assets/85446214/0cea38c5-51de-4399-ad8a-84b27e9b8efb">

<img width="1210" alt="Screenshot 2024-01-12 at 18 52 38" src="https://github.com/entropy-code/entropay-employees/assets/85446214/67a9e4ee-cc65-41c4-8fa2-896e0300339b">
