### PR TITLE
EN-155: Cannot create a client once it was Deleted

### DIFF
--- a/src/main/java/com/entropyteam/entropay/employees/models/Client.java
+++ b/src/main/java/com/entropyteam/entropay/employees/models/Client.java
@@ -19,7 +19,7 @@ public class Client extends BaseEntity {
     @JoinColumn(name = "company_id")
     private Company company;
 
-    @Column(unique = true, nullable = false)
+    @Column(nullable = false)
     private String name;
 
     @Embedded

--- a/src/main/resources/db/migration/V44.0__DDL_update_client_table.sql
+++ b/src/main/resources/db/migration/V44.0__DDL_update_client_table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE client DROP CONSTRAINT uc_clients_name;


### PR DESCRIPTION
# Description :pencil:

Deleted a constraint enabling clients to be created once they have been deleted
## Link to ticket :link:

https://entropyteam.atlassian.net/browse/EN-155

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? :microscope: