### PR TITLE
EN-162: Displayed unassigned Client when group by Client

### DIFF
--- a/src/main/java/com/entropyteam/entropay/employees/dtos/PtoReportClientDto.java
+++ b/src/main/java/com/entropyteam/entropay/employees/dtos/PtoReportClientDto.java
@@ -3,12 +3,12 @@ package com.entropyteam.entropay.employees.dtos;
 import java.util.UUID;
 
 public class PtoReportClientDto extends ReportDto{
-    private UUID id;
+    private String id;
     private String clientName;
     private Double totalDays;
     private Integer year;
 
-    public PtoReportClientDto(UUID id,
+    public PtoReportClientDto(String id,
                                 String clientName,
                                 Double totalDays,
                                 Integer year) {
@@ -18,11 +18,11 @@ public class PtoReportClientDto extends ReportDto{
         this.year = year;
     }
 
-    public UUID getId() {
+    public String getId() {
         return id;
     }
 
-    public void setId(UUID id) {
+    public void setId(String id) {
         this.id = id;
     }
 

--- a/src/main/java/com/entropyteam/entropay/employees/repositories/AssignmentRepository.java
+++ b/src/main/java/com/entropyteam/entropay/employees/repositories/AssignmentRepository.java
@@ -25,11 +25,11 @@ public interface AssignmentRepository extends BaseRepository<Assignment, UUID> {
     List<Assignment> findAllAssignmentsToActivateInDate(@Param("date") LocalDate date);
 
     @Query(value = "SELECT a.* FROM assignment AS a INNER JOIN project AS p ON a.project_id = p.id WHERE p.client_id = :clientId AND a.deleted = false " +
-            " AND p.deleted = FALSE", nativeQuery = true)
+            " AND p.deleted = FALSE AND a.active = true", nativeQuery = true)
     List<Assignment> findAllAssignmentsByClientId(@Param("clientId") UUID clientId);
 
     @Query(value = "SELECT a.* FROM assignment AS a INNER JOIN project AS p ON a.project_id = p.id WHERE p.client_id IN :clientIds AND a.deleted = false " +
-            " AND p.deleted = FALSE", nativeQuery = true)
+            " AND p.deleted = FALSE AND a.active = true", nativeQuery = true)
     List<Assignment> findAllAssignmentsByClientIdIn(@Param("clientIds") List<UUID> clientIds);
 
     List<Assignment> findAllByEmployeeIdInAndDeletedIsFalse(List<UUID> employeesId);

--- a/src/main/java/com/entropyteam/entropay/employees/repositories/EmployeeRepository.java
+++ b/src/main/java/com/entropyteam/entropay/employees/repositories/EmployeeRepository.java
@@ -18,4 +18,9 @@ public interface EmployeeRepository extends BaseRepository<Employee, UUID> {
     List<Employee> getEmployeesWithAtLeastAnActiveContract();
 
     List<Employee> findAllByIdInAndDeletedIsFalse(List<UUID> employeesIds);
+
+    @Query(value = "SELECT e.* FROM Employee AS e WHERE e.deleted = false AND e.active = true AND NOT EXISTS(" +
+            "SELECT * FROM Assignment AS a WHERE e.id = a.employee_id AND a.active = true AND a.deleted = false)",
+            nativeQuery = true)
+    List<Employee> findAllUnassignedEmployees();
 }

--- a/src/main/java/com/entropyteam/entropay/employees/services/EmployeeService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/services/EmployeeService.java
@@ -281,15 +281,4 @@ public class EmployeeService extends BaseService<Employee, EmployeeDto, UUID> {
         int yearDiff = startDate.until(currentDate).getYears();
         return yearDiff >= 5 ? 20 : (yearDiff >= 2 ? 15 : activeContract.get().getSeniority().getVacationDays());
     }
-
-    public List<Employee> getUnassignedEmployees(){
-        List<Employee> fullEmployeesList = employeeRepository.findAllByDeletedIsFalseAndActiveIsTrue();
-        List<Client> clientList = clientRepository.findAllClientsWithAProject();
-        List<Assignment> assignmentsList = assignmentRepository.findAllAssignmentsByClientIdIn(clientList.stream().map(BaseEntity::getId).collect(Collectors.toList()))
-                .stream().toList();
-
-        return fullEmployeesList.stream()
-                .filter(employee -> !assignmentsList.stream().map(assignment -> assignment.getEmployee().getId()).toList().contains(employee.getId()))
-                .collect(Collectors.toList());
-    }
 }

--- a/src/main/java/com/entropyteam/entropay/employees/services/EmployeeService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/services/EmployeeService.java
@@ -58,7 +58,6 @@ public class EmployeeService extends BaseService<Employee, EmployeeDto, UUID> {
     private final VacationRepository vacationRepository;
     private final PtoRepository ptoRepository;
     private final CountryRepository countryRepository;
-    private final ClientRepository clientRepository;
     private final GoogleService googleService;
 
 
@@ -68,7 +67,7 @@ public class EmployeeService extends BaseService<Employee, EmployeeDto, UUID> {
                            PaymentInformationService paymentInformationService, TechnologyRepository technologyRepository,
                            AssignmentRepository assignmentRepository, ContractRepository contractRepository,
                            ReactAdminMapper reactAdminMapper, VacationRepository vacationRepository, PtoRepository ptoRepository,
-                           CountryRepository countryRepository, GoogleService googleService, ClientRepository clientRepository) {
+                           CountryRepository countryRepository, GoogleService googleService) {
         super(Employee.class, reactAdminMapper);
         this.employeeRepository = employeeRepository;
         this.roleRepository = roleRepository;
@@ -80,7 +79,6 @@ public class EmployeeService extends BaseService<Employee, EmployeeDto, UUID> {
         this.vacationRepository = vacationRepository;
         this.ptoRepository = ptoRepository;
         this.countryRepository = countryRepository;
-        this.clientRepository = clientRepository;
         this.googleService = googleService;
     }
 


### PR DESCRIPTION
# Description :pencil:

In time off reporting those employees that do not have an assigned client now appear on the Gropy by Client under "No client" name.
Group by client detail is also working and shows the details of those ptos taken by employees without an assigned client

## Link to ticket :link:

https://entropyteam.atlassian.net/browse/EN-162

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? :microscope:

![image](https://github.com/entropy-code/entropay-employees/assets/89614950/ce451d4a-3cfe-4311-afd5-77aeb8be0426)
