### PR TITLE
Fix issue with leave events not being deleted from calendar

### DIFF
--- a/src/main/java/com/entropyteam/entropay/employees/calendar/GoogleCalendarService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/calendar/GoogleCalendarService.java
@@ -89,7 +89,8 @@ public class GoogleCalendarService implements CalendarService {
 
     @Override
     public void deleteLeaveEvent(String leaveId) {
-        deleteGoogleCalendarEvent(leaveId);
+        String eventId = getLeaveEventId(leaveId);
+        deleteGoogleCalendarEvent(eventId);
     }
 
     private static Event buildBirthdayEvent(String employeeId, String firstName, String lastName, LocalDate birthDate) {


### PR DESCRIPTION
# Description :pencil:

We were using the ID of the leave event in DB format instead of the custom format for leave events.

## Link to ticket :link:

https://3.basecamp.com/5776473/buckets/37034902/todos/7928527109

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? :microscope:

Tested locally.
