### PR TITLE
remove method that was trying to restrict the fields but it was actua…

### DIFF
--- a/.github/workflows/deploy-prod-aws.yml
+++ b/.github/workflows/deploy-prod-aws.yml
@@ -122,10 +122,10 @@ jobs:
         with:
           ref: main
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
 
       - name: Set next version
@@ -144,7 +144,7 @@ jobs:
           commit-message: Prepare next dev version
           committer: GitHub <noreply@github.com>
           branch: next-version-${{ steps.set-next-version.outputs.NEXT_VERSION }}
-          base: develop
+          base: main
           delete-branch: true
           title: 'Prepare next dev version'
           body: |

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.entropyteam.entropay</groupId>
     <artifactId>entropay-employees</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.2.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>entropay-employees</name>
     <description>Entropay Employees API</description>

--- a/src/main/java/com/entropyteam/entropay/common/BaseService.java
+++ b/src/main/java/com/entropyteam/entropay/common/BaseService.java
@@ -132,7 +132,7 @@ public abstract class BaseService<Entity extends BaseEntity, DTO, Key> implement
             return CollectionUtils.emptyCollection();
         }
         Collection<Predicate> predicates =
-                filter.getGetByFieldsFilter().entrySet().stream().filter(f -> f.getKey() != SEARCH_TERM_KEY)
+                filter.getGetByFieldsFilter().entrySet().stream().filter(f -> !SEARCH_TERM_KEY.equals(f.getKey()))
                         .map(f -> cb.equal(root.get(f.getKey()), f.getValue())).collect(Collectors.toSet());
 
         if (filter.getGetByDateFieldsFilter().containsKey(DATE_TO_TERM_KEY) && filter.getGetByDateFieldsFilter()

--- a/src/main/java/com/entropyteam/entropay/employees/services/ContractService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/services/ContractService.java
@@ -173,19 +173,6 @@ public class ContractService extends BaseService<Contract, ContractDto, UUID> {
     }
 
     @Override
-    public Map<String, Object> getRestrictedFields(AppRole userRole) {
-        Map<String, Object> restrictedFields = new HashMap<>();
-        if (AppRole.ROLE_MANAGER_HR.equals(userRole)) {
-            List<Role> roles = roleRepository.findAllByDeletedIsFalseAndNameLikeIgnoreCase(HR_SEARCH_TERM);
-            if (CollectionUtils.isNotEmpty(roles)) {
-                restrictedFields.put("role", roles);
-            }
-        }
-
-        return restrictedFields;
-    }
-
-    @Override
     public Map<String, List<String>> getRelatedColumnsForSearch() {
         Map<String, List<String>> relatedColumns = new HashMap<>();
         relatedColumns.put("employee", Arrays.asList("firstName", "lastName"));


### PR DESCRIPTION
This pull request includes several updates and improvements across different files in the project. The most significant changes include updating the Java Development Kit (JDK) version, modifying the branch base for deployment, updating the project version, refining a predicate filter, and removing an unused method.

### Updates and improvements:

* **JDK Version Update:**
  * [`.github/workflows/deploy-prod-aws.yml`](diffhunk://#diff-b2c4ce22afe0e329602a82847f4a315add3b996305dfe14c56d49c8a53bb4431L125-R128): Updated the JDK version from 17 to 21.

* **Deployment Configuration:**
  * [`.github/workflows/deploy-prod-aws.yml`](diffhunk://#diff-b2c4ce22afe0e329602a82847f4a315add3b996305dfe14c56d49c8a53bb4431L147-R147): Changed the base branch for deployment from `develop` to `main`.

* **Project Version Update:**
  * [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L14-R14): Updated the project version from `1.2.0-SNAPSHOT` to `1.2.1-SNAPSHOT`.

* **Predicate Filter Refinement:**
  * [`src/main/java/com/entropyteam/entropay/common/BaseService.java`](diffhunk://#diff-f63df3d50d9df2d964b2d41be0e3aaca71d956dbc6b9be458de29a8a2cbc5a33L135-R135): Refined the predicate filter to use `SEARCH_TERM_KEY.equals(f.getKey())` for better null safety.

* **Code Cleanup:**
  * [`src/main/java/com/entropyteam/entropay/employees/services/ContractService.java`](diffhunk://#diff-36859d81a642bb8c0075d14686198f0006aa464185a201b347acdeb585c9e345L175-L187): Removed the unused `getRestrictedFields` method because it had a bug and I prefered to remove it than to fix it.