### PR TITLE
Add BirthdayJob to notify employee birthdays

### DIFF
--- a/src/main/java/com/entropyteam/entropay/employees/jobs/BirthdayJob.java
+++ b/src/main/java/com/entropyteam/entropay/employees/jobs/BirthdayJob.java
@@ -1,0 +1,137 @@
+package com.entropyteam.entropay.employees.jobs;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import com.entropyteam.entropay.employees.models.Employee;
+import com.entropyteam.entropay.employees.repositories.EmployeeRepository;
+import com.entropyteam.entropay.notifications.MessageDto;
+import com.entropyteam.entropay.notifications.MessageType;
+import com.entropyteam.entropay.notifications.NotificationService;
+
+/**
+ * Job that sends notifications about employee birthdays.
+ * Runs Monday-Friday at 9:00 AM GMT-3.
+ * On Mondays, it also checks for birthdays from the weekend.
+ */
+@Component
+public class BirthdayJob {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BirthdayJob.class);
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+
+    private final EmployeeRepository employeeRepository;
+    private final NotificationService notificationService;
+
+    @Autowired
+    public BirthdayJob(EmployeeRepository employeeRepository, NotificationService notificationService) {
+        this.employeeRepository = employeeRepository;
+        this.notificationService = notificationService;
+    }
+
+    /**
+     * Scheduled job that runs Monday-Friday at 9:00 AM GMT-3.
+     * Sends notifications about employee birthdays.
+     */
+    @Scheduled(cron = "0 0 9 ? * MON-FRI", zone = "GMT-3")
+    @Transactional(readOnly = true)
+    public void notifyBirthdays() {
+        LOGGER.info("Starting birthday notification job");
+
+        List<LocalDate> datesToCheck = getDatesToCheck();
+
+        // Get all active and non-deleted employees
+        List<Employee> allEmployees = employeeRepository.findAllByDeletedIsFalseAndActiveIsTrue();
+
+        // Filter employees with birthdays on the dates to check
+        List<Employee> birthdayEmployees = allEmployees.stream()
+                .filter(employee -> employee.getBirthDate() != null)
+                .filter(employee -> datesToCheck.stream()
+                        .anyMatch(date -> isSameDayAndMonth(employee.getBirthDate(), date)))
+                .collect(Collectors.toList());
+
+        if (!birthdayEmployees.isEmpty()) {
+            LOGGER.info("Found {} employees with birthdays", birthdayEmployees.size());
+            sendBirthdayNotification(birthdayEmployees);
+        } else {
+            LOGGER.info("No birthdays found for today");
+        }
+    }
+
+    /**
+     * Checks if two dates have the same day and month (ignoring year).
+     *
+     * @param date1 First date to compare
+     * @param date2 Second date to compare
+     * @return true if the day and month are the same, false otherwise
+     */
+    private boolean isSameDayAndMonth(LocalDate date1, LocalDate date2) {
+        return date1.getDayOfMonth() == date2.getDayOfMonth() 
+                && date1.getMonth() == date2.getMonth();
+    }
+
+
+    /**
+     * Gets the list of dates to check for birthdays.
+     * If today is Monday, it includes the weekend days (Saturday and Sunday).
+     * Otherwise, it only includes today.
+     *
+     * @return List of dates to check for birthdays
+     */
+    private List<LocalDate> getDatesToCheck() {
+        LocalDate today = LocalDate.now();
+
+        if (today.getDayOfWeek() == DayOfWeek.MONDAY) {
+            LOGGER.info("Today is Monday, checking weekend birthdays as well");
+
+            List<LocalDate> datesToCheck = List.of(
+                    today.minusDays(2), // Saturday
+                    today.minusDays(1), // Sunday
+                    today               // Monday
+            );
+
+            LOGGER.info("Checked for birthdays on weekend and today: {}", datesToCheck);
+            return datesToCheck;
+        } else {
+            LOGGER.info("Checked for birthdays on: {}", today);
+            return List.of(today);
+        }
+    }
+
+    /**
+     * Sends a notification with the list of employees having birthdays.
+     *
+     * @param employees List of employees with birthdays
+     */
+    private void sendBirthdayNotification(List<Employee> employees) {
+        StringBuilder messageBuilder = new StringBuilder();
+
+        for (Employee employee : employees) {
+            messageBuilder
+                    .append(employee.getInternalId())
+                    .append(" - ")
+                    .append(employee.getFullName())
+                    .append(" - ")
+                    .append(employee.getBirthDate().format(DATE_FORMATTER))
+                    .append("\n");
+        }
+
+        // Create and send the notification
+        MessageDto birthdayMessage = new MessageDto(
+                "Employee Birthdays",
+                messageBuilder.toString(),
+                MessageType.BIRTHDAY
+        );
+
+        notificationService.sendNotification(birthdayMessage);
+        LOGGER.info("Birthday notification sent for {} employees", employees.size());
+    }
+}

--- a/src/test/java/com/entropyteam/entropay/employees/jobs/BirthdayJobTest.java
+++ b/src/test/java/com/entropyteam/entropay/employees/jobs/BirthdayJobTest.java
@@ -1,0 +1,228 @@
+package com.entropyteam.entropay.employees.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import com.entropyteam.entropay.employees.models.Employee;
+import com.entropyteam.entropay.employees.repositories.EmployeeRepository;
+import com.entropyteam.entropay.notifications.MessageDto;
+import com.entropyteam.entropay.notifications.MessageType;
+import com.entropyteam.entropay.notifications.NotificationService;
+
+@ExtendWith(MockitoExtension.class)
+class BirthdayJobTest {
+
+    @Mock
+    private EmployeeRepository employeeRepository;
+
+    @Mock
+    private NotificationService notificationService;
+
+    @InjectMocks
+    private BirthdayJob birthdayJob;
+
+    @Captor
+    private ArgumentCaptor<MessageDto> messageCaptor;
+
+    private Employee employee1;
+    private Employee employee2;
+
+    @BeforeEach
+    void setUp() {
+        // Create test employees
+        employee1 = new Employee();
+        employee1.setId(UUID.randomUUID());
+        employee1.setFirstName("John");
+        employee1.setLastName("Doe");
+        employee1.setBirthDate(LocalDate.of(1990, Month.JANUARY, 15));
+        employee1.setActive(true);
+        employee1.setInternalId("E001");
+
+        employee2 = new Employee();
+        employee2.setId(UUID.randomUUID());
+        employee2.setFirstName("Jane");
+        employee2.setLastName("Smith");
+        employee2.setBirthDate(LocalDate.of(1985, Month.JANUARY, 16));
+        employee2.setActive(true);
+        employee2.setInternalId("E002");
+
+        Employee employee3 = new Employee();
+        employee3.setId(UUID.randomUUID());
+        employee3.setFirstName("Bob");
+        employee3.setLastName("Johnson");
+        employee3.setBirthDate(LocalDate.of(1995, Month.JANUARY, 17));
+        employee3.setActive(true);
+        employee3.setInternalId("E003");
+    }
+
+    @Test
+    void shouldSendNotificationForEmployeesWithBirthdayToday() {
+        // Given
+        LocalDate today = LocalDate.of(2023, Month.JANUARY, 15); // Same day as employee1's birthday
+
+        // Create another employee with a different birthday
+        Employee anotherEmployee = new Employee();
+        anotherEmployee.setId(UUID.randomUUID());
+        anotherEmployee.setFirstName("Another");
+        anotherEmployee.setLastName("Person");
+        anotherEmployee.setBirthDate(LocalDate.of(1990, Month.FEBRUARY, 15)); // Different month
+        anotherEmployee.setActive(true);
+        anotherEmployee.setInternalId("E004");
+
+        // Mock the repository to return all active employees
+        when(employeeRepository.findAllByDeletedIsFalseAndActiveIsTrue())
+                .thenReturn(List.of(employee1, anotherEmployee));
+
+        // When
+        // Mock LocalDate.now() to return our test date
+        try (var mockedStatic = mockStatic(LocalDate.class)) {
+            mockedStatic.when(LocalDate::now).thenReturn(today);
+            birthdayJob.notifyBirthdays();
+        }
+
+        // Then
+        verify(notificationService).sendNotification(messageCaptor.capture());
+        MessageDto capturedMessage = messageCaptor.getValue();
+
+        assertEquals(MessageType.BIRTHDAY, capturedMessage.messageType());
+        assertEquals("Employee Birthdays", capturedMessage.title());
+        assertTrue(capturedMessage.message().contains("John Doe"));
+        assertTrue(capturedMessage.message().contains("15/01/1990"));
+        assertTrue(capturedMessage.message().contains("E001"));
+        assertFalse(capturedMessage.message().contains("Another Person"));
+        assertFalse(capturedMessage.message().contains("Jane Smith"));
+        assertFalse(capturedMessage.message().contains("Bob Johnson"));
+    }
+
+    @Test
+    void shouldIncludeWeekendBirthdaysOnMonday() {
+        // Given
+        LocalDate monday = LocalDate.of(2023, Month.JANUARY, 16); // Monday
+
+        // Create employees with weekend birthdays
+        Employee saturdayEmployee = new Employee();
+        saturdayEmployee.setId(UUID.randomUUID());
+        saturdayEmployee.setFirstName("Saturday");
+        saturdayEmployee.setLastName("Person");
+        saturdayEmployee.setBirthDate(LocalDate.of(1980, Month.JANUARY, 14)); // Birthday on Saturday
+        saturdayEmployee.setActive(true);
+        saturdayEmployee.setInternalId("E004");
+
+        Employee sundayEmployee = employee1; // Birthday on Sunday (January 15)
+        sundayEmployee.setBirthDate(LocalDate.of(1990, Month.JANUARY, 15)); // Ensure correct date
+
+        Employee mondayEmployee = employee2; // Birthday on Monday (January 16)
+        mondayEmployee.setBirthDate(LocalDate.of(1985, Month.JANUARY, 16)); // Ensure correct date
+
+        // Create another employee with a different birthday
+        Employee anotherEmployee = new Employee();
+        anotherEmployee.setId(UUID.randomUUID());
+        anotherEmployee.setFirstName("Another");
+        anotherEmployee.setLastName("Person");
+        anotherEmployee.setBirthDate(LocalDate.of(1990, Month.FEBRUARY, 15)); // Different month
+        anotherEmployee.setActive(true);
+        anotherEmployee.setInternalId("E005");
+
+        // Mock the repository to return all active employees
+        when(employeeRepository.findAllByDeletedIsFalseAndActiveIsTrue())
+                .thenReturn(List.of(saturdayEmployee, sundayEmployee, mondayEmployee, anotherEmployee));
+
+        // When
+        try (var mockedStatic = mockStatic(LocalDate.class)) {
+            mockedStatic.when(LocalDate::now).thenReturn(monday);
+            birthdayJob.notifyBirthdays();
+        }
+
+        // Then
+        verify(notificationService).sendNotification(messageCaptor.capture());
+        MessageDto capturedMessage = messageCaptor.getValue();
+
+        assertTrue(capturedMessage.message().contains("Saturday Person"));
+        assertTrue(capturedMessage.message().contains("John Doe"));
+        assertTrue(capturedMessage.message().contains("Jane Smith"));
+        assertFalse(capturedMessage.message().contains("Another Person"));
+        assertFalse(capturedMessage.message().contains("Bob Johnson"));
+    }
+
+    @Test
+    void shouldNotSendNotificationWhenNoBirthdays() {
+        // Given
+        LocalDate today = LocalDate.of(2023, Month.FEBRUARY, 1); // No birthdays on this date
+
+        // Create employees with birthdays on different dates
+        Employee employee = new Employee();
+        employee.setId(UUID.randomUUID());
+        employee.setFirstName("No");
+        employee.setLastName("Match");
+        employee.setBirthDate(LocalDate.of(1990, Month.MARCH, 15)); // Different month and day
+        employee.setActive(true);
+        employee.setInternalId("E006");
+
+        // Mock the repository to return employees with no birthdays on today's date
+        when(employeeRepository.findAllByDeletedIsFalseAndActiveIsTrue())
+                .thenReturn(List.of(employee));
+
+        // When
+        try (var mockedStatic = mockStatic(LocalDate.class)) {
+            mockedStatic.when(LocalDate::now).thenReturn(today);
+            birthdayJob.notifyBirthdays();
+        }
+
+        // Then
+        verify(notificationService, never()).sendNotification(any());
+    }
+
+    @Test
+    void shouldNotSendNotificationWhenNoBirthdaysOnMonday() {
+        // Given
+        LocalDate monday = LocalDate.of(2023, Month.FEBRUARY, 6); // Monday with no birthdays
+
+        // Create employees with birthdays on different dates (not on weekend or Monday)
+        Employee employee1 = new Employee();
+        employee1.setId(UUID.randomUUID());
+        employee1.setFirstName("No");
+        employee1.setLastName("Match1");
+        employee1.setBirthDate(LocalDate.of(1990, Month.MARCH, 15)); // Different month and day
+        employee1.setActive(true);
+        employee1.setInternalId("E007");
+
+        Employee employee2 = new Employee();
+        employee2.setId(UUID.randomUUID());
+        employee2.setFirstName("No");
+        employee2.setLastName("Match2");
+        employee2.setBirthDate(LocalDate.of(1990, Month.FEBRUARY, 7)); // Day after Monday
+        employee2.setActive(true);
+        employee2.setInternalId("E008");
+
+        // Mock the repository to return employees with no birthdays on weekend or Monday
+        when(employeeRepository.findAllByDeletedIsFalseAndActiveIsTrue())
+                .thenReturn(List.of(employee1, employee2));
+
+        // When
+        try (var mockedStatic = mockStatic(LocalDate.class)) {
+            mockedStatic.when(LocalDate::now).thenReturn(monday);
+            birthdayJob.notifyBirthdays();
+        }
+
+        // Then
+        verify(notificationService, never()).sendNotification(any());
+    }
+}


### PR DESCRIPTION
This pull request introduces a new scheduled job, `BirthdayJob`, to notify about employee birthdays and includes comprehensive unit tests to validate its functionality. The key changes are as follows:

### New Feature: Birthday Notification Job
* Added the `BirthdayJob` class in `src/main/java/com/entropyteam/entropay/employees/jobs/BirthdayJob.java`. This job:
  - Runs Monday-Friday at 9:00 AM GMT-3.
  - Notifies about employee birthdays, including weekend birthdays on Mondays.
  - Filters active and non-deleted employees and checks their birth dates against the current date or weekend dates.

### Unit Testing: BirthdayJob
* Added the `BirthdayJobTest` class in `src/test/java/com/entropyteam/entropay/employees/jobs/BirthdayJobTest.java` to test the functionality of `BirthdayJob`. Key tests include:
  - Verifying notifications are sent for employees with birthdays on the current day.
  - Ensuring weekend birthdays are included in notifications on Mondays.
  - Confirming no notifications are sent when there are no birthdays on the relevant dates.