### PR TITLE
Add fetch join support to BaseService and EmployeeService

### DIFF
--- a/src/main/java/com/entropyteam/entropay/common/BaseService.java
+++ b/src/main/java/com/entropyteam/entropay/common/BaseService.java
@@ -67,6 +67,7 @@ public abstract class BaseService<Entity extends BaseEntity, DTO, Key> implement
             CriteriaBuilder cb = session.getCriteriaBuilder();
             CriteriaQuery<Entity> entityQuery = cb.createQuery(entityClass);
             Root<Entity> root = entityQuery.from(entityClass);
+            addFetchJoins(root);
 
             List<Predicate> predicates = getPredicates(cb, root, filter);
             entityQuery.select(root).where(cb.and(predicates.toArray(new Predicate[0])));
@@ -233,5 +234,8 @@ public abstract class BaseService<Entity extends BaseEntity, DTO, Key> implement
 
     protected Collection<Predicate> buildCustomFieldsPredicates(Root<Entity> root, Filter filter, CriteriaBuilder cb) {
         return CollectionUtils.emptyCollection();
+    }
+
+    protected void addFetchJoins(Root<Entity> root) {
     }
 }

--- a/src/main/java/com/entropyteam/entropay/employees/services/EmployeeService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/services/EmployeeService.java
@@ -26,13 +26,12 @@ import com.entropyteam.entropay.common.Filter;
 import com.entropyteam.entropay.common.ReactAdminMapper;
 import com.entropyteam.entropay.employees.calendar.CalendarService;
 import com.entropyteam.entropay.employees.dtos.EmployeeDto;
+import com.entropyteam.entropay.employees.dtos.PaymentInformationDto;
 import com.entropyteam.entropay.employees.models.Assignment;
 import com.entropyteam.entropay.employees.models.Contract;
 import com.entropyteam.entropay.employees.models.Country;
 import com.entropyteam.entropay.employees.models.Employee;
-import com.entropyteam.entropay.employees.models.EmployeeEducation;
 import com.entropyteam.entropay.employees.models.Holiday;
-import com.entropyteam.entropay.employees.dtos.PaymentInformationDto;
 import com.entropyteam.entropay.employees.models.PaymentInformation;
 import com.entropyteam.entropay.employees.models.Role;
 import com.entropyteam.entropay.employees.repositories.AssignmentRepository;
@@ -43,6 +42,7 @@ import com.entropyteam.entropay.employees.repositories.RoleRepository;
 import com.entropyteam.entropay.employees.repositories.VacationRepository;
 
 import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import jakarta.persistence.criteria.Subquery;
@@ -312,5 +312,10 @@ public class EmployeeService extends BaseService<Employee, EmployeeDto, UUID> {
         }
 
         return predicates;
+    }
+
+    @Override
+    protected void addFetchJoins(Root<Employee> root) {
+        root.fetch("education", JoinType.LEFT);
     }
 }


### PR DESCRIPTION
This pull request introduces a new mechanism for adding fetch joins to JPA queries in the base service layer, and applies it specifically in the `EmployeeService` to eagerly fetch employee education data. The changes improve extensibility and performance when dealing with related entities.

Enhancements to entity fetching:

* Added a protected `addFetchJoins` method to `BaseService`, allowing subclasses to specify fetch joins for their queries. The method is called in `findAllActive` to enable this extensibility. [[1]](diffhunk://#diff-f63df3d50d9df2d964b2d41be0e3aaca71d956dbc6b9be458de29a8a2cbc5a33R70) [[2]](diffhunk://#diff-f63df3d50d9df2d964b2d41be0e3aaca71d956dbc6b9be458de29a8a2cbc5a33R238-R240)
* Overrode `addFetchJoins` in `EmployeeService` to fetch the `education` relationship with a left join, ensuring education data is loaded eagerly with employee entities.

Code cleanup:

* Cleaned up imports in `EmployeeService.java` to remove unused classes and organize dependencies. [[1]](diffhunk://#diff-f2df3fc90b37ae8675ceae6ae31d3ceec10accb47a200439c1f2ea74f1f99a14R29-L35) [[2]](diffhunk://#diff-f2df3fc90b37ae8675ceae6ae31d3ceec10accb47a200439c1f2ea74f1f99a14R45)