### PR TITLE
Add Payroll module: PayrollRun + PayrollItem with async calculation

### DIFF
--- a/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollAsyncConfig.java
+++ b/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollAsyncConfig.java
@@ -1,0 +1,69 @@
+package com.entropyteam.entropay.employees.payroll;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+class PayrollAsyncConfig {
+
+    @Value("${payroll.executor.core-pool-size:4}")
+    private int corePoolSize;
+
+    @Value("${payroll.executor.max-pool-size:8}")
+    private int maxPoolSize;
+
+    @Value("${payroll.executor.queue-capacity:2000}")
+    private int queueCapacity;
+
+    @Value("${payroll.dispatch-executor.core-pool-size:2}")
+    private int dispatchCorePoolSize;
+
+    @Value("${payroll.dispatch-executor.max-pool-size:2}")
+    private int dispatchMaxPoolSize;
+
+    @Value("${payroll.dispatch-executor.queue-capacity:10}")
+    private int dispatchQueueCapacity;
+
+    /**
+     * Pool that runs the per-employee calculation fan-out. Sized for real headcount; a
+     * {@link ThreadPoolExecutor.CallerRunsPolicy} rejection handler is the safety net so an
+     * oversized company can never overflow the queue into a {@code RejectedExecutionException}.
+     */
+    @Bean(name = "payrollExecutor")
+    public Executor payrollExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(corePoolSize);
+        executor.setMaxPoolSize(maxPoolSize);
+        executor.setQueueCapacity(queueCapacity);
+        executor.setThreadNamePrefix("payroll-");
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(60);
+        executor.initialize();
+        return executor;
+    }
+
+    /**
+     * Small dedicated pool for the {@code @Async} run-dispatch entrypoint. Kept separate from
+     * {@code payrollExecutor} so the dispatch thread can never starve or contend with the
+     * calculation fan-out it submits and joins on. One thread per concurrently-allowed run.
+     */
+    @Bean(name = "payrollDispatchExecutor")
+    public Executor payrollDispatchExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(dispatchCorePoolSize);
+        executor.setMaxPoolSize(dispatchMaxPoolSize);
+        executor.setQueueCapacity(dispatchQueueCapacity);
+        executor.setThreadNamePrefix("payroll-dispatch-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(120);
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollCalculatorService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollCalculatorService.java
@@ -1,0 +1,335 @@
+package com.entropyteam.entropay.employees.payroll;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import com.entropyteam.entropay.employees.models.Contract;
+import com.entropyteam.entropay.employees.models.Currency;
+import com.entropyteam.entropay.employees.models.Employee;
+import com.entropyteam.entropay.employees.models.Modality;
+import com.entropyteam.entropay.employees.models.Overtime;
+import com.entropyteam.entropay.employees.models.PaymentSettlement;
+import com.entropyteam.entropay.employees.models.Pto;
+import com.entropyteam.entropay.employees.models.Reimbursement;
+import com.entropyteam.entropay.employees.models.Vacation;
+
+/**
+ * Pure calculator for a single employee's payroll. No DB access — all required data lives on the
+ * passed-in {@link PayrollContext}, so multiple invocations can run in parallel safely.
+ * <p>
+ * Any unexpected failure for a single contract is captured in {@link PayrollItem#getCalculationError()}
+ * with zeroed totals; the caller never sees an exception, so one bad row cannot abort the whole run.
+ */
+@Service
+class PayrollCalculatorService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PayrollCalculatorService.class);
+    private static final int HOURS_PER_BUSINESS_DAY = 8;
+    private static final int HOURS_PER_HALF_DAY = 4;
+    /** Intermediate scale for monthly-to-hourly / monthly-to-daily rate divisions. */
+    private static final int RATE_SCALE = 4;
+    private static final int MONEY_SCALE = 2;
+    /** Fixed monthly-to-daily divisor (~average business days per month). */
+    private static final BigDecimal MONTHLY_WORKING_DAYS = new BigDecimal("21.6");
+    /** Fixed monthly-to-hourly divisor — used to derive an employee's hourly cost from a monthly salary. */
+    private static final BigDecimal MONTHLY_WORKING_HOURS =
+            MONTHLY_WORKING_DAYS.multiply(BigDecimal.valueOf(HOURS_PER_BUSINESS_DAY));
+    /** {@link com.entropyteam.entropay.employees.models.LeaveType#getName()} value used in prod to flag unpaid leave. */
+    static final String UNPAID_LEAVE_TYPE = "Unpaid License";
+
+    public PayrollItem calculate(Contract contract, PayrollContext ctx) {
+        PayrollItem item = new PayrollItem();
+        item.setContract(contract);
+        Employee employee = contract.getEmployee();
+        item.setEmployee(employee);
+        item.setClientName(ctx.clientNameByEmployeeId().get(employee.getId()));
+        item.setPaymentPlatform(ctx.paymentPlatformByEmployeeId().get(employee.getId()));
+
+        try {
+            return doCalculate(item, contract, ctx);
+        } catch (RuntimeException e) {
+            LOGGER.error("Payroll calculation failed for employee {}: {}",
+                    employee.getInternalId(), e.getMessage(), e);
+            item.setCalculationError(truncate(e.getClass().getSimpleName() + ": " + e.getMessage()));
+            return item;
+        }
+    }
+
+    private PayrollItem doCalculate(PayrollItem item, Contract contract, PayrollContext ctx) {
+        Optional<PaymentSettlement> primary = pickPrimarySettlement(contract);
+        if (primary.isEmpty()) {
+            item.setCalculationError("Contract has no payment settlement");
+            return item;
+        }
+        PaymentSettlement settlement = primary.get();
+        Modality modality = settlement.getModality();
+        BigDecimal settlementSalary = nz(settlement.getSalary());
+        item.setModality(modality);
+
+        Employee employee = contract.getEmployee();
+        UUID employeeId = employee.getId();
+        UUID countryId = employee.getCountry() != null ? employee.getCountry().getId() : null;
+        YearMonth ym = YearMonth.from(ctx.period());
+        LocalDate periodStart = ym.atDay(1);
+        LocalDate periodEnd = ym.atEndOfMonth();
+
+        int countryWorkingHours = countryId != null
+                ? ctx.workingHoursByCountryId().getOrDefault(countryId, 0)
+                : 0;
+        item.setCountryWorkingHoursInMonth(countryWorkingHours);
+
+        Set<LocalDate> countryHolidays = countryId != null
+                ? ctx.holidayDatesByCountryId().getOrDefault(countryId, Collections.emptySet())
+                : Collections.emptySet();
+
+        List<Pto> ptos = ctx.ptosByEmployeeId().getOrDefault(employeeId, Collections.emptyList());
+        BigDecimal ptoHours = ptos.stream()
+                .map(p -> hoursForPtoInMonth(p, periodStart, periodEnd, countryHolidays))
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        item.setPtoHoursInMonth(ptoHours);
+
+        // Unpaid leave: paid holidays inside the leave range stay paid, so they're excluded from the deduction.
+        BigDecimal unpaidLeaveHours = ptos.stream()
+                .filter(PayrollCalculatorService::isUnpaidLeave)
+                .map(p -> hoursForPtoInMonth(p, periodStart, periodEnd, countryHolidays))
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        item.setUnpaidLeaveHoursInMonth(unpaidLeaveHours);
+
+        BigDecimal billableHours = BigDecimal.valueOf(countryWorkingHours).subtract(ptoHours);
+        if (billableHours.signum() < 0) {
+            billableHours = BigDecimal.ZERO;
+        }
+        item.setBillableHoursInMonth(billableHours);
+
+        // Base salary / proportional
+        boolean coversFullMonth = !contract.getStartDate().isAfter(periodStart)
+                                  && (contract.getEndDate() == null || !contract.getEndDate().isBefore(periodEnd));
+        boolean isFinalSettlement = contract.getEndDate() != null
+                                    && !contract.getEndDate().isBefore(periodStart)
+                                    && !contract.getEndDate().isAfter(periodEnd);
+        item.setFinalSettlement(isFinalSettlement);
+
+        if (modality == Modality.MONTHLY) {
+            if (coversFullMonth) {
+                item.setBaseSalary(settlementSalary);
+                item.setProportionalSalary(BigDecimal.ZERO);
+            } else {
+                LocalDate workStart =
+                        contract.getStartDate().isAfter(periodStart) ? contract.getStartDate() : periodStart;
+                LocalDate workEnd = contract.getEndDate() != null && contract.getEndDate().isBefore(periodEnd)
+                        ? contract.getEndDate() : periodEnd;
+                // Holidays are a paid benefit: count weekdays in the worked range without subtracting holidays.
+                int workedDays = countBusinessDays(workStart, workEnd, Collections.emptySet());
+                BigDecimal dailyRate = computeDailyRate(modality, settlementSalary);
+                BigDecimal proportional = dailyRate.multiply(BigDecimal.valueOf(workedDays))
+                        .setScale(MONEY_SCALE, RoundingMode.HALF_UP);
+                item.setBaseSalary(BigDecimal.ZERO);
+                item.setProportionalSalary(proportional);
+            }
+        } else { // HOUR
+            BigDecimal hourBased = settlementSalary.multiply(billableHours).setScale(MONEY_SCALE, RoundingMode.HALF_UP);
+            item.setBaseSalary(hourBased);
+            item.setProportionalSalary(BigDecimal.ZERO);
+        }
+
+        // Unpaid leave deduction: only MONTHLY needs an explicit subtraction — for HOUR the unpaid hours
+        // already drop out of billableHours and never enter baseSalary, so there's nothing extra to deduct.
+        if (modality == Modality.MONTHLY && unpaidLeaveHours.signum() > 0) {
+            BigDecimal hourlyCost = computeHourlyRate(modality, settlementSalary);
+            BigDecimal deduction = hourlyCost.multiply(unpaidLeaveHours)
+                    .setScale(MONEY_SCALE, RoundingMode.HALF_UP);
+            item.setUnpaidLeaveDeduction(deduction);
+        }
+
+        // Overtime — uses the employee's hourly cost (salary / 21.6 / 8 for MONTHLY), not the client billable rate.
+        BigDecimal hourlyRate = computeHourlyRate(modality, settlementSalary);
+        List<Overtime> overtimes = ctx.overtimesByEmployeeId().getOrDefault(employeeId, Collections.emptyList());
+        // Route through the float's string representation: BigDecimal.valueOf(float) widens to double
+        // first, which introduces binary drift (e.g. 2.1f → 2.0999...). Float.toString gives the
+        // shortest decimal that round-trips to the same float, so 2.1f → "2.1" → exactly 2.1.
+        BigDecimal overtimeHours = overtimes.stream()
+                .map(o -> new BigDecimal(Float.toString(o.getHours())))
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal overtimeAmount = overtimeHours.multiply(hourlyRate).setScale(MONEY_SCALE, RoundingMode.HALF_UP);
+        item.setOvertimeHours(overtimeHours);
+        item.setOvertimeAmount(overtimeAmount);
+
+        // Reimbursements — paid in USD like everything else.
+        List<Reimbursement> reimbursements =
+                ctx.reimbursementsByEmployeeId().getOrDefault(employeeId, Collections.emptyList());
+        BigDecimal reimbursementsTotal = reimbursements.stream()
+                .map(Reimbursement::getAmount)
+                .map(PayrollCalculatorService::nz)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        item.setReimbursementsAmount(reimbursementsTotal);
+
+        // Final settlement: vacation cashout + hardware clawback if early termination.
+        if (isFinalSettlement) {
+            BigDecimal valuePerDay = computeDailyRate(modality, settlementSalary);
+            int unusedDays =
+                    unusedVacationDays(ctx.vacationsByEmployeeId().getOrDefault(employeeId, Collections.emptyList()));
+            BigDecimal cashout =
+                    valuePerDay.multiply(BigDecimal.valueOf(unusedDays)).setScale(MONEY_SCALE, RoundingMode.HALF_UP);
+            item.setVacationCashout(cashout);
+
+            LocalDate hireDate = ctx.hireDateByEmployeeId().getOrDefault(employeeId, contract.getStartDate());
+            long monthsServed = hireDate != null
+                    ? ChronoUnit.MONTHS.between(YearMonth.from(hireDate), ym)
+                    : Long.MAX_VALUE;
+            if (monthsServed < 12) {
+                List<Reimbursement> hardware =
+                        ctx.hardwareReimbursementsLast12mByEmployeeId()
+                                .getOrDefault(employeeId, Collections.emptyList());
+                if (hardware.isEmpty()) {
+                    LOGGER.warn(
+                            "Final settlement for employee {} (months served={}) but no Hardware reimbursements found"
+                            + " in last 12 months — clawback set to 0; review manually.",
+                            employee.getInternalId(), monthsServed);
+                }
+                BigDecimal clawback = hardware.stream()
+                        .map(Reimbursement::getAmount)
+                        .map(PayrollCalculatorService::nz)
+                        .reduce(BigDecimal.ZERO, BigDecimal::add);
+                item.setHardwareClawback(clawback);
+            }
+        }
+
+        recomputeTotals(item);
+        return item;
+    }
+
+    /**
+     * Recompute the total after adjustments change. Pure — call from {@link PayrollItemService}
+     * when the user edits adjustment / previousBalance / notes so the persisted total stays in sync.
+     */
+    public void recomputeTotals(PayrollItem item) {
+        BigDecimal total = nz(item.getBaseSalary())
+                .add(nz(item.getProportionalSalary()))
+                .add(nz(item.getOvertimeAmount()))
+                .add(nz(item.getReimbursementsAmount()))
+                .add(nz(item.getAdjustment()))
+                .add(nz(item.getPreviousBalance()))
+                .add(nz(item.getVacationCashout()))
+                .subtract(nz(item.getHardwareClawback()))
+                .subtract(nz(item.getUnpaidLeaveDeduction()));
+        item.setTotalAmount(total.setScale(MONEY_SCALE, RoundingMode.HALF_UP));
+    }
+
+    static Optional<PaymentSettlement> pickPrimarySettlement(Contract contract) {
+        if (contract.getPaymentsSettlement() == null || contract.getPaymentsSettlement().isEmpty()) {
+            return Optional.empty();
+        }
+        // Prefer MONTHLY USD (Entropy's typical contract), then any MONTHLY, then any HOUR, then any.
+        return contract.getPaymentsSettlement().stream()
+                .filter(p -> p.getModality() == Modality.MONTHLY && p.getCurrency() == Currency.USD)
+                .findFirst()
+                .or(() -> contract.getPaymentsSettlement().stream()
+                        .filter(p -> p.getModality() == Modality.MONTHLY)
+                        .findFirst())
+                .or(() -> contract.getPaymentsSettlement().stream()
+                        .filter(p -> p.getModality() == Modality.HOUR)
+                        .findFirst())
+                .or(() -> contract.getPaymentsSettlement().stream().findFirst());
+    }
+
+    static boolean isUnpaidLeave(Pto pto) {
+        return pto.getLeaveType() != null
+                && UNPAID_LEAVE_TYPE.equalsIgnoreCase(pto.getLeaveType().getName());
+    }
+
+    static int countBusinessDays(LocalDate start, LocalDate end, Set<LocalDate> holidays) {
+        int days = 0;
+        LocalDate cursor = start;
+        while (!cursor.isAfter(end)) {
+            DayOfWeek dow = cursor.getDayOfWeek();
+            if (dow != DayOfWeek.SATURDAY && dow != DayOfWeek.SUNDAY && !holidays.contains(cursor)) {
+                days++;
+            }
+            cursor = cursor.plusDays(1);
+        }
+        return days;
+    }
+
+    static BigDecimal hoursForPtoInMonth(Pto pto, LocalDate periodStart, LocalDate periodEnd,
+            Set<LocalDate> countryHolidays) {
+        if (pto.getStartDate() == null || pto.getEndDate() == null) {
+            return BigDecimal.ZERO;
+        }
+        LocalDate ptoStart = pto.getStartDate();
+        LocalDate ptoEnd = pto.getEndDate();
+        LocalDate overlapStart = ptoStart.isAfter(periodStart) ? ptoStart : periodStart;
+        LocalDate overlapEnd = ptoEnd.isBefore(periodEnd) ? ptoEnd : periodEnd;
+        if (overlapEnd.isBefore(overlapStart)) {
+            return BigDecimal.ZERO;
+        }
+        boolean fullyInMonth = !ptoStart.isBefore(periodStart) && !ptoEnd.isAfter(periodEnd);
+        if (fullyInMonth && pto.getLabourHours() != null && pto.getLabourHours() > 0) {
+            return BigDecimal.valueOf(pto.getLabourHours());
+        }
+        int businessDaysOverlap = countBusinessDays(overlapStart, overlapEnd, countryHolidays);
+        int hoursPerDay = pto.isHalfDay() ? HOURS_PER_HALF_DAY : HOURS_PER_BUSINESS_DAY;
+        return BigDecimal.valueOf((long) hoursPerDay * businessDaysOverlap);
+    }
+
+    static BigDecimal computeHourlyRate(Modality modality, BigDecimal salary) {
+        if (modality == Modality.HOUR) {
+            return salary;
+        }
+        return salary.divide(MONTHLY_WORKING_HOURS, RATE_SCALE, RoundingMode.HALF_UP);
+    }
+
+    static BigDecimal computeDailyRate(Modality modality, BigDecimal salary) {
+        if (modality == Modality.HOUR) {
+            return salary.multiply(BigDecimal.valueOf(HOURS_PER_BUSINESS_DAY));
+        }
+        return salary.divide(MONTHLY_WORKING_DAYS, RATE_SCALE, RoundingMode.HALF_UP);
+    }
+
+    static int unusedVacationDays(List<Vacation> vacations) {
+        // Business rule (per CTO): include ALL accumulated years (no year filter), sum the net
+        // (credit - debit) across rows so a year with debit > credit subtracts from positive years,
+        // then floor the FINAL net at zero. Never floor per row — that would over-pay.
+        int net = vacations.stream()
+                .mapToInt(v -> nzInt(v.getCredit()) - nzInt(v.getDebit()))
+                .sum();
+        return Math.max(net, 0);
+    }
+
+    /**
+     * Returns the given BigDecimal value if it is not null. If the input value is null, returns BigDecimal.ZERO.
+     *
+     * @param v the BigDecimal value to check for null
+     * @return the original BigDecimal value if not null, otherwise BigDecimal.ZERO
+     */
+    static BigDecimal nz(BigDecimal v) {
+        return v == null ? BigDecimal.ZERO : v;
+    }
+
+    /**
+     * Returns the given Integer value if it is not null. If the input value is null, returns 0.
+     *
+     * @param v the Integer value to check for null
+     * @return the original Integer value if not null, otherwise 0
+     */
+    static int nzInt(Integer v) {
+        return v == null ? 0 : v;
+    }
+
+    static String truncate(String s) {
+        if (s == null) {
+            return null;
+        }
+        return s.length() <= 1990 ? s : s.substring(0, 1990) + "...";
+    }
+}

--- a/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollContext.java
+++ b/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollContext.java
@@ -1,0 +1,34 @@
+package com.entropyteam.entropay.employees.payroll;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import com.entropyteam.entropay.employees.models.Contract;
+import com.entropyteam.entropay.employees.models.Overtime;
+import com.entropyteam.entropay.employees.models.Pto;
+import com.entropyteam.entropay.employees.models.Reimbursement;
+import com.entropyteam.entropay.employees.models.Vacation;
+
+/**
+ * Snapshot of every piece of data needed to compute a payroll for the given month.
+ * Built once by {@link PayrollDataLoader} inside a single read-only transaction; the calculator
+ * works exclusively against this immutable view, so per-employee calculations never round-trip
+ * to the database and can be parallelized safely.
+ */
+record PayrollContext(
+        LocalDate period,
+        List<Contract> contracts,
+        Map<UUID, List<Overtime>> overtimesByEmployeeId,
+        Map<UUID, List<Reimbursement>> reimbursementsByEmployeeId,
+        Map<UUID, List<Reimbursement>> hardwareReimbursementsLast12mByEmployeeId,
+        Map<UUID, List<Vacation>> vacationsByEmployeeId,
+        Map<UUID, List<Pto>> ptosByEmployeeId,
+        Map<UUID, Set<LocalDate>> holidayDatesByCountryId,
+        Map<UUID, Integer> workingHoursByCountryId,
+        Map<UUID, String> clientNameByEmployeeId,
+        Map<UUID, String> paymentPlatformByEmployeeId,
+        Map<UUID, LocalDate> hireDateByEmployeeId
+) {
+}

--- a/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollDataLoader.java
+++ b/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollDataLoader.java
@@ -5,7 +5,6 @@ import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -18,16 +17,17 @@ import org.springframework.transaction.annotation.Transactional;
 import com.entropyteam.entropay.employees.models.Assignment;
 import com.entropyteam.entropay.employees.models.Contract;
 import com.entropyteam.entropay.employees.models.Country;
-import com.entropyteam.entropay.employees.models.Employee;
 import com.entropyteam.entropay.employees.models.Holiday;
 import com.entropyteam.entropay.employees.models.Overtime;
 import com.entropyteam.entropay.employees.models.PaymentInformation;
 import com.entropyteam.entropay.employees.models.Pto;
 import com.entropyteam.entropay.employees.models.Reimbursement;
 import com.entropyteam.entropay.employees.models.Vacation;
+import com.entropyteam.entropay.employees.repositories.AssignmentRepository;
 import com.entropyteam.entropay.employees.repositories.ContractRepository;
 import com.entropyteam.entropay.employees.repositories.HolidayRepository;
 import com.entropyteam.entropay.employees.repositories.OvertimeRepository;
+import com.entropyteam.entropay.employees.repositories.PaymentInformationRepository;
 import com.entropyteam.entropay.employees.repositories.PtoRepository;
 import com.entropyteam.entropay.employees.repositories.ReimbursementRepository;
 import com.entropyteam.entropay.employees.repositories.VacationRepository;
@@ -45,19 +45,25 @@ class PayrollDataLoader {
     private final VacationRepository vacationRepository;
     private final PtoRepository ptoRepository;
     private final HolidayRepository holidayRepository;
+    private final AssignmentRepository assignmentRepository;
+    private final PaymentInformationRepository paymentInformationRepository;
 
     public PayrollDataLoader(ContractRepository contractRepository,
             OvertimeRepository overtimeRepository,
             ReimbursementRepository reimbursementRepository,
             VacationRepository vacationRepository,
             PtoRepository ptoRepository,
-            HolidayRepository holidayRepository) {
+            HolidayRepository holidayRepository,
+            AssignmentRepository assignmentRepository,
+            PaymentInformationRepository paymentInformationRepository) {
         this.contractRepository = contractRepository;
         this.overtimeRepository = overtimeRepository;
         this.reimbursementRepository = reimbursementRepository;
         this.vacationRepository = vacationRepository;
         this.ptoRepository = ptoRepository;
         this.holidayRepository = holidayRepository;
+        this.assignmentRepository = assignmentRepository;
+        this.paymentInformationRepository = paymentInformationRepository;
     }
 
     @Transactional(readOnly = true)
@@ -96,9 +102,11 @@ class PayrollDataLoader {
                 .filter(r -> HARDWARE_CATEGORY_NAME.equalsIgnoreCase(r.getCategory().getName()))
                 .collect(Collectors.groupingBy(r -> r.getEmployee().getId()));
 
-        Map<UUID, List<Vacation>> vacationsByEmployee = vacationRepository.findAllByDeletedIsFalse().stream()
-                .filter(v -> v.getEmployee() != null && employeeIds.contains(v.getEmployee().getId()))
-                .collect(Collectors.groupingBy(v -> v.getEmployee().getId()));
+        Map<UUID, List<Vacation>> vacationsByEmployee = employeeIds.isEmpty()
+                ? new HashMap<>()
+                : vacationRepository.findAllByEmployeeIdInAndDeletedIsFalse(employeeIds).stream()
+                        .filter(v -> v.getEmployee() != null)
+                        .collect(Collectors.groupingBy(v -> v.getEmployee().getId()));
 
         Map<UUID, List<Pto>> ptosByEmployee = ptoRepository.findAllBetweenPeriod(periodStart, periodEnd).stream()
                 .filter(p -> p.getEmployee() != null && employeeIds.contains(p.getEmployee().getId()))
@@ -122,11 +130,24 @@ class PayrollDataLoader {
 
         Map<UUID, String> clientNameByEmployee = new HashMap<>();
         Map<UUID, String> platformByEmployee = new HashMap<>();
-        for (Contract c : contracts) {
-            Employee e = c.getEmployee();
-            UUID empId = e.getId();
-            clientNameByEmployee.computeIfAbsent(empId, k -> findClientName(e, periodStart, periodEnd));
-            platformByEmployee.computeIfAbsent(empId, k -> findPlatform(e));
+        if (!employeeIds.isEmpty()) {
+            // Bulk-fetch assignments (with project + client) and payment information instead of
+            // touching Employee.assignments / Employee.paymentsInformation in a loop, which would
+            // trigger one extra SELECT per employee per collection.
+            for (Assignment a : assignmentRepository.findActiveByEmployeeIdInOverlappingPeriod(
+                    employeeIds, periodStart, periodEnd)) {
+                if (a.getEmployee() == null) {
+                    continue;
+                }
+                clientNameByEmployee.putIfAbsent(a.getEmployee().getId(), projectClientName(a));
+            }
+            for (PaymentInformation pi : paymentInformationRepository
+                    .findAllByEmployeeIdInAndDeletedIsFalse(employeeIds)) {
+                if (pi.getEmployee() == null || pi.getPlatform() == null) {
+                    continue;
+                }
+                platformByEmployee.putIfAbsent(pi.getEmployee().getId(), pi.getPlatform());
+            }
         }
 
         Map<UUID, LocalDate> hireDateByEmployee = new HashMap<>();
@@ -165,20 +186,7 @@ class PayrollDataLoader {
         return days * HOURS_PER_BUSINESS_DAY;
     }
 
-    private String findClientName(Employee employee, LocalDate periodStart, LocalDate periodEnd) {
-        if (employee.getAssignments() == null) {
-            return null;
-        }
-        return employee.getAssignments().stream()
-                .filter(a -> a.getStartDate() == null || !a.getStartDate().isAfter(periodEnd))
-                .filter(a -> a.getEndDate() == null || !a.getEndDate().isBefore(periodStart))
-                .filter(Assignment::isActive)
-                .findFirst()
-                .map(this::projectClientName)
-                .orElse(null);
-    }
-
-    private String projectClientName(Assignment assignment) {
+    private static String projectClientName(Assignment assignment) {
         if (assignment.getProject() == null) {
             return null;
         }
@@ -186,17 +194,6 @@ class PayrollDataLoader {
             return assignment.getProject().getClient().getName();
         }
         return assignment.getProject().getName();
-    }
-
-    private String findPlatform(Employee employee) {
-        if (employee.getPaymentsInformation() == null) {
-            return null;
-        }
-        return employee.getPaymentsInformation().stream()
-                .map(PaymentInformation::getPlatform)
-                .filter(java.util.Objects::nonNull)
-                .findFirst()
-                .orElse(null);
     }
 
     /** Visible for test packaging — explicit empty list builder. */

--- a/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollDataLoader.java
+++ b/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollDataLoader.java
@@ -1,0 +1,206 @@
+package com.entropyteam.entropay.employees.payroll;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import com.entropyteam.entropay.employees.models.Assignment;
+import com.entropyteam.entropay.employees.models.Contract;
+import com.entropyteam.entropay.employees.models.Country;
+import com.entropyteam.entropay.employees.models.Employee;
+import com.entropyteam.entropay.employees.models.Holiday;
+import com.entropyteam.entropay.employees.models.Overtime;
+import com.entropyteam.entropay.employees.models.PaymentInformation;
+import com.entropyteam.entropay.employees.models.Pto;
+import com.entropyteam.entropay.employees.models.Reimbursement;
+import com.entropyteam.entropay.employees.models.Vacation;
+import com.entropyteam.entropay.employees.repositories.ContractRepository;
+import com.entropyteam.entropay.employees.repositories.HolidayRepository;
+import com.entropyteam.entropay.employees.repositories.OvertimeRepository;
+import com.entropyteam.entropay.employees.repositories.PtoRepository;
+import com.entropyteam.entropay.employees.repositories.ReimbursementRepository;
+import com.entropyteam.entropay.employees.repositories.VacationRepository;
+
+@Service
+class PayrollDataLoader {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PayrollDataLoader.class);
+    private static final int HOURS_PER_BUSINESS_DAY = 8;
+    private static final String HARDWARE_CATEGORY_NAME = "Bono de Hardware";
+
+    private final ContractRepository contractRepository;
+    private final OvertimeRepository overtimeRepository;
+    private final ReimbursementRepository reimbursementRepository;
+    private final VacationRepository vacationRepository;
+    private final PtoRepository ptoRepository;
+    private final HolidayRepository holidayRepository;
+
+    public PayrollDataLoader(ContractRepository contractRepository,
+            OvertimeRepository overtimeRepository,
+            ReimbursementRepository reimbursementRepository,
+            VacationRepository vacationRepository,
+            PtoRepository ptoRepository,
+            HolidayRepository holidayRepository) {
+        this.contractRepository = contractRepository;
+        this.overtimeRepository = overtimeRepository;
+        this.reimbursementRepository = reimbursementRepository;
+        this.vacationRepository = vacationRepository;
+        this.ptoRepository = ptoRepository;
+        this.holidayRepository = holidayRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public PayrollContext loadContext(LocalDate period) {
+        YearMonth ym = YearMonth.from(period);
+        LocalDate periodStart = ym.atDay(1);
+        LocalDate periodEnd = ym.atEndOfMonth();
+        LocalDate twelveMonthsBack = periodEnd.minusMonths(12).plusDays(1);
+
+        List<Contract> contracts = contractRepository.findAllOverlappingPeriodForPayroll(periodStart, periodEnd);
+        LOGGER.info("Loaded {} contracts for payroll period {}", contracts.size(), ym);
+
+        Set<UUID> employeeIds = contracts.stream()
+                .map(c -> c.getEmployee().getId())
+                .collect(Collectors.toSet());
+        Set<UUID> countryIds = contracts.stream()
+                .map(c -> c.getEmployee().getCountry())
+                .filter(java.util.Objects::nonNull)
+                .map(Country::getId)
+                .collect(Collectors.toSet());
+
+        Map<UUID, List<Overtime>> overtimesByEmployee =
+                overtimeRepository.findByDateBetweenAndDeletedIsFalse(periodStart, periodEnd).stream()
+                .filter(o -> o.getEmployee() != null)
+                .collect(Collectors.groupingBy(o -> o.getEmployee().getId()));
+
+        Map<UUID, List<Reimbursement>> reimbursementsByEmployee =
+                reimbursementRepository.findAllBetweenPeriod(periodStart, periodEnd).stream()
+                .filter(r -> r.getEmployee() != null)
+                .collect(Collectors.groupingBy(r -> r.getEmployee().getId()));
+
+        List<Reimbursement> last12mReimbursements =
+                reimbursementRepository.findAllBetweenPeriod(twelveMonthsBack, periodEnd);
+        Map<UUID, List<Reimbursement>> hardwareLast12m = last12mReimbursements.stream()
+                .filter(r -> r.getEmployee() != null && r.getCategory() != null)
+                .filter(r -> HARDWARE_CATEGORY_NAME.equalsIgnoreCase(r.getCategory().getName()))
+                .collect(Collectors.groupingBy(r -> r.getEmployee().getId()));
+
+        Map<UUID, List<Vacation>> vacationsByEmployee = vacationRepository.findAllByDeletedIsFalse().stream()
+                .filter(v -> v.getEmployee() != null && employeeIds.contains(v.getEmployee().getId()))
+                .collect(Collectors.groupingBy(v -> v.getEmployee().getId()));
+
+        Map<UUID, List<Pto>> ptosByEmployee = ptoRepository.findAllBetweenPeriod(periodStart, periodEnd).stream()
+                .filter(p -> p.getEmployee() != null && employeeIds.contains(p.getEmployee().getId()))
+                .collect(Collectors.groupingBy(p -> p.getEmployee().getId()));
+
+        Map<UUID, Set<LocalDate>> holidayDatesByCountry = new HashMap<>();
+        Map<UUID, Integer> workingHoursByCountry = new HashMap<>();
+        if (!countryIds.isEmpty()) {
+            List<Holiday> holidays = holidayRepository.findAllBetweenPeriod(periodStart, periodEnd);
+            for (UUID countryId : countryIds) {
+                Set<LocalDate> dates = holidays.stream()
+                        .filter(h -> h.getCountry() != null
+                                && (countryId.equals(h.getCountry().getId())
+                                || "ALL".equalsIgnoreCase(h.getCountry().getName())))
+                        .map(Holiday::getDate)
+                        .collect(Collectors.toSet());
+                holidayDatesByCountry.put(countryId, dates);
+                workingHoursByCountry.put(countryId, computeWorkingHours(periodStart, periodEnd, dates));
+            }
+        }
+
+        Map<UUID, String> clientNameByEmployee = new HashMap<>();
+        Map<UUID, String> platformByEmployee = new HashMap<>();
+        for (Contract c : contracts) {
+            Employee e = c.getEmployee();
+            UUID empId = e.getId();
+            clientNameByEmployee.computeIfAbsent(empId, k -> findClientName(e, periodStart, periodEnd));
+            platformByEmployee.computeIfAbsent(empId, k -> findPlatform(e));
+        }
+
+        Map<UUID, LocalDate> hireDateByEmployee = new HashMap<>();
+        if (!employeeIds.isEmpty()) {
+            for (Object[] row : contractRepository.findEarliestStartDateByEmployeeIds(employeeIds)) {
+                hireDateByEmployee.put((UUID) row[0], (LocalDate) row[1]);
+            }
+        }
+
+        return new PayrollContext(
+                periodStart,
+                contracts,
+                overtimesByEmployee,
+                reimbursementsByEmployee,
+                hardwareLast12m,
+                vacationsByEmployee,
+                ptosByEmployee,
+                holidayDatesByCountry,
+                workingHoursByCountry,
+                clientNameByEmployee,
+                platformByEmployee,
+                hireDateByEmployee
+        );
+    }
+
+    static int computeWorkingHours(LocalDate start, LocalDate end, Set<LocalDate> holidays) {
+        int days = 0;
+        LocalDate cursor = start;
+        while (!cursor.isAfter(end)) {
+            DayOfWeek dow = cursor.getDayOfWeek();
+            if (dow != DayOfWeek.SATURDAY && dow != DayOfWeek.SUNDAY && !holidays.contains(cursor)) {
+                days++;
+            }
+            cursor = cursor.plusDays(1);
+        }
+        return days * HOURS_PER_BUSINESS_DAY;
+    }
+
+    private String findClientName(Employee employee, LocalDate periodStart, LocalDate periodEnd) {
+        if (employee.getAssignments() == null) {
+            return null;
+        }
+        return employee.getAssignments().stream()
+                .filter(a -> a.getStartDate() == null || !a.getStartDate().isAfter(periodEnd))
+                .filter(a -> a.getEndDate() == null || !a.getEndDate().isBefore(periodStart))
+                .filter(Assignment::isActive)
+                .findFirst()
+                .map(this::projectClientName)
+                .orElse(null);
+    }
+
+    private String projectClientName(Assignment assignment) {
+        if (assignment.getProject() == null) {
+            return null;
+        }
+        if (assignment.getProject().getClient() != null) {
+            return assignment.getProject().getClient().getName();
+        }
+        return assignment.getProject().getName();
+    }
+
+    private String findPlatform(Employee employee) {
+        if (employee.getPaymentsInformation() == null) {
+            return null;
+        }
+        return employee.getPaymentsInformation().stream()
+                .map(PaymentInformation::getPlatform)
+                .filter(java.util.Objects::nonNull)
+                .findFirst()
+                .orElse(null);
+    }
+
+    /** Visible for test packaging — explicit empty list builder. */
+    static List<Reimbursement> emptyReimbursements() {
+        return new ArrayList<>();
+    }
+}

--- a/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollItem.java
+++ b/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollItem.java
@@ -1,0 +1,292 @@
+package com.entropyteam.entropay.employees.payroll;
+
+import java.math.BigDecimal;
+import com.entropyteam.entropay.common.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import com.entropyteam.entropay.employees.models.Contract;
+import com.entropyteam.entropay.employees.models.Employee;
+import com.entropyteam.entropay.employees.models.Modality;
+
+@Entity(name = "PayrollItem")
+@Table(name = "payroll_item")
+class PayrollItem extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "payroll_run_id", nullable = false)
+    private PayrollRun payrollRun;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "employee_id", nullable = false)
+    private Employee employee;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "contract_id")
+    private Contract contract;
+
+    @Column(name = "client_name")
+    private String clientName;
+
+    @Column(name = "payment_platform")
+    private String paymentPlatform;
+
+    @Enumerated(EnumType.STRING)
+    @Column
+    private Modality modality;
+
+    @Column(name = "base_salary", precision = 14, scale = 2)
+    private BigDecimal baseSalary = BigDecimal.ZERO;
+
+    @Column(name = "proportional_salary", precision = 14, scale = 2)
+    private BigDecimal proportionalSalary = BigDecimal.ZERO;
+
+    @Column(name = "country_working_hours_in_month")
+    private Integer countryWorkingHoursInMonth;
+
+    @Column(name = "pto_hours_in_month", precision = 8, scale = 2)
+    private BigDecimal ptoHoursInMonth = BigDecimal.ZERO;
+
+    @Column(name = "unpaid_leave_hours_in_month", precision = 8, scale = 2)
+    private BigDecimal unpaidLeaveHoursInMonth = BigDecimal.ZERO;
+
+    @Column(name = "unpaid_leave_deduction", precision = 14, scale = 2)
+    private BigDecimal unpaidLeaveDeduction = BigDecimal.ZERO;
+
+    @Column(name = "billable_hours_in_month", precision = 8, scale = 2)
+    private BigDecimal billableHoursInMonth = BigDecimal.ZERO;
+
+    @Column(name = "overtime_hours", precision = 8, scale = 2)
+    private BigDecimal overtimeHours = BigDecimal.ZERO;
+
+    @Column(name = "overtime_amount", precision = 14, scale = 2)
+    private BigDecimal overtimeAmount = BigDecimal.ZERO;
+
+    @Column(name = "reimbursements_amount", precision = 14, scale = 2)
+    private BigDecimal reimbursementsAmount = BigDecimal.ZERO;
+
+    @Column(name = "hardware_clawback", precision = 14, scale = 2)
+    private BigDecimal hardwareClawback = BigDecimal.ZERO;
+
+    @Column(name = "vacation_cashout", precision = 14, scale = 2)
+    private BigDecimal vacationCashout = BigDecimal.ZERO;
+
+    @Column(name = "adjustment", precision = 14, scale = 2)
+    private BigDecimal adjustment = BigDecimal.ZERO;
+
+    @Column(name = "previous_balance", precision = 14, scale = 2)
+    private BigDecimal previousBalance = BigDecimal.ZERO;
+
+    @Column(length = 1000)
+    private String notes;
+
+    @Column(name = "total_amount", precision = 14, scale = 2)
+    private BigDecimal totalAmount = BigDecimal.ZERO;
+
+    @Column(name = "is_final_settlement")
+    private boolean isFinalSettlement;
+
+    @Column(name = "calculation_error", length = 2000)
+    private String calculationError;
+
+    public PayrollItem() {
+    }
+
+    public PayrollRun getPayrollRun() {
+        return payrollRun;
+    }
+
+    public void setPayrollRun(PayrollRun payrollRun) {
+        this.payrollRun = payrollRun;
+    }
+
+    public Employee getEmployee() {
+        return employee;
+    }
+
+    public void setEmployee(Employee employee) {
+        this.employee = employee;
+    }
+
+    public Contract getContract() {
+        return contract;
+    }
+
+    public void setContract(Contract contract) {
+        this.contract = contract;
+    }
+
+    public String getClientName() {
+        return clientName;
+    }
+
+    public void setClientName(String clientName) {
+        this.clientName = clientName;
+    }
+
+    public String getPaymentPlatform() {
+        return paymentPlatform;
+    }
+
+    public void setPaymentPlatform(String paymentPlatform) {
+        this.paymentPlatform = paymentPlatform;
+    }
+
+    public Modality getModality() {
+        return modality;
+    }
+
+    public void setModality(Modality modality) {
+        this.modality = modality;
+    }
+
+    public BigDecimal getBaseSalary() {
+        return baseSalary;
+    }
+
+    public void setBaseSalary(BigDecimal baseSalary) {
+        this.baseSalary = baseSalary;
+    }
+
+    public BigDecimal getProportionalSalary() {
+        return proportionalSalary;
+    }
+
+    public void setProportionalSalary(BigDecimal proportionalSalary) {
+        this.proportionalSalary = proportionalSalary;
+    }
+
+    public Integer getCountryWorkingHoursInMonth() {
+        return countryWorkingHoursInMonth;
+    }
+
+    public void setCountryWorkingHoursInMonth(Integer countryWorkingHoursInMonth) {
+        this.countryWorkingHoursInMonth = countryWorkingHoursInMonth;
+    }
+
+    public BigDecimal getPtoHoursInMonth() {
+        return ptoHoursInMonth;
+    }
+
+    public void setPtoHoursInMonth(BigDecimal ptoHoursInMonth) {
+        this.ptoHoursInMonth = ptoHoursInMonth;
+    }
+
+    public BigDecimal getUnpaidLeaveHoursInMonth() {
+        return unpaidLeaveHoursInMonth;
+    }
+
+    public void setUnpaidLeaveHoursInMonth(BigDecimal unpaidLeaveHoursInMonth) {
+        this.unpaidLeaveHoursInMonth = unpaidLeaveHoursInMonth;
+    }
+
+    public BigDecimal getUnpaidLeaveDeduction() {
+        return unpaidLeaveDeduction;
+    }
+
+    public void setUnpaidLeaveDeduction(BigDecimal unpaidLeaveDeduction) {
+        this.unpaidLeaveDeduction = unpaidLeaveDeduction;
+    }
+
+    public BigDecimal getBillableHoursInMonth() {
+        return billableHoursInMonth;
+    }
+
+    public void setBillableHoursInMonth(BigDecimal billableHoursInMonth) {
+        this.billableHoursInMonth = billableHoursInMonth;
+    }
+
+    public BigDecimal getOvertimeHours() {
+        return overtimeHours;
+    }
+
+    public void setOvertimeHours(BigDecimal overtimeHours) {
+        this.overtimeHours = overtimeHours;
+    }
+
+    public BigDecimal getOvertimeAmount() {
+        return overtimeAmount;
+    }
+
+    public void setOvertimeAmount(BigDecimal overtimeAmount) {
+        this.overtimeAmount = overtimeAmount;
+    }
+
+    public BigDecimal getReimbursementsAmount() {
+        return reimbursementsAmount;
+    }
+
+    public void setReimbursementsAmount(BigDecimal reimbursementsAmount) {
+        this.reimbursementsAmount = reimbursementsAmount;
+    }
+
+    public BigDecimal getHardwareClawback() {
+        return hardwareClawback;
+    }
+
+    public void setHardwareClawback(BigDecimal hardwareClawback) {
+        this.hardwareClawback = hardwareClawback;
+    }
+
+    public BigDecimal getVacationCashout() {
+        return vacationCashout;
+    }
+
+    public void setVacationCashout(BigDecimal vacationCashout) {
+        this.vacationCashout = vacationCashout;
+    }
+
+    public BigDecimal getAdjustment() {
+        return adjustment;
+    }
+
+    public void setAdjustment(BigDecimal adjustment) {
+        this.adjustment = adjustment;
+    }
+
+    public BigDecimal getPreviousBalance() {
+        return previousBalance;
+    }
+
+    public void setPreviousBalance(BigDecimal previousBalance) {
+        this.previousBalance = previousBalance;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
+    public BigDecimal getTotalAmount() {
+        return totalAmount;
+    }
+
+    public void setTotalAmount(BigDecimal totalAmount) {
+        this.totalAmount = totalAmount;
+    }
+
+    public boolean isFinalSettlement() {
+        return isFinalSettlement;
+    }
+
+    public void setFinalSettlement(boolean finalSettlement) {
+        isFinalSettlement = finalSettlement;
+    }
+
+    public String getCalculationError() {
+        return calculationError;
+    }
+
+    public void setCalculationError(String calculationError) {
+        this.calculationError = calculationError;
+    }
+}

--- a/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollItemController.java
+++ b/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollItemController.java
@@ -1,0 +1,52 @@
+package com.entropyteam.entropay.employees.payroll;
+
+import static com.entropyteam.entropay.auth.AuthConstants.ROLE_ADMIN;
+import static com.entropyteam.entropay.auth.AuthConstants.ROLE_HR_DIRECTOR;
+import static com.entropyteam.entropay.auth.AuthConstants.ROLE_MANAGER_HR;
+
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import com.entropyteam.entropay.common.BaseController;
+import com.entropyteam.entropay.common.ReactAdminParams;
+
+/**
+ * REST surface for individual payroll items. Inherited list/get/update from {@link BaseController};
+ * the service rejects create/delete and gates update behind run-status DRAFT.
+ *
+ * <p>{@code getList}/{@code getOne} are overridden to re-declare {@code @Secured} without
+ * {@code ROLE_ANALYST}/{@code ROLE_DEVELOPMENT}: payroll items expose company-wide salary data, so
+ * the inherited method-level annotations (which would otherwise override this class-level
+ * restriction) must not be allowed to widen access.
+ */
+@RestController
+@CrossOrigin
+@RequestMapping(value = "/payroll-items", produces = MediaType.APPLICATION_JSON_VALUE)
+@Secured({ROLE_ADMIN, ROLE_HR_DIRECTOR, ROLE_MANAGER_HR})
+class PayrollItemController extends BaseController<PayrollItemDto, UUID> {
+
+    public PayrollItemController(PayrollItemService payrollItemService) {
+        super(payrollItemService);
+    }
+
+    @Override
+    @GetMapping
+    @Secured({ROLE_ADMIN, ROLE_HR_DIRECTOR, ROLE_MANAGER_HR})
+    public ResponseEntity<List<PayrollItemDto>> getList(ReactAdminParams params) {
+        return super.getList(params);
+    }
+
+    @Override
+    @GetMapping("/{id}")
+    @Secured({ROLE_ADMIN, ROLE_HR_DIRECTOR, ROLE_MANAGER_HR})
+    public ResponseEntity<PayrollItemDto> getOne(@PathVariable(value = "id") UUID id) {
+        return super.getOne(id);
+    }
+}

--- a/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollItemController.java
+++ b/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollItemController.java
@@ -6,25 +6,31 @@ import static com.entropyteam.entropay.auth.AuthConstants.ROLE_MANAGER_HR;
 
 import java.util.List;
 import java.util.UUID;
+import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import com.entropyteam.entropay.common.BaseController;
 import com.entropyteam.entropay.common.ReactAdminParams;
 
 /**
- * REST surface for individual payroll items. Inherited list/get/update from {@link BaseController};
- * the service rejects create/delete and gates update behind run-status DRAFT.
+ * REST surface for individual payroll items. Inherited from {@link BaseController}; the service
+ * rejects create/delete and gates update behind run-status DRAFT.
  *
- * <p>{@code getList}/{@code getOne} are overridden to re-declare {@code @Secured} without
- * {@code ROLE_ANALYST}/{@code ROLE_DEVELOPMENT}: payroll items expose company-wide salary data, so
- * the inherited method-level annotations (which would otherwise override this class-level
- * restriction) must not be allowed to widen access.
+ * <p>Every CRUD method is re-declared with {@code @Secured({ROLE_ADMIN, ROLE_HR_DIRECTOR,
+ * ROLE_MANAGER_HR})}. The class-level {@code @Secured} alone is not enough: Spring's method-level
+ * {@code @Secured} on the inherited methods (e.g. {@code BaseController.update}, which permits
+ * {@code ROLE_DEVELOPMENT}) takes precedence and would otherwise widen access to company-wide
+ * salary data.
  */
 @RestController
 @CrossOrigin
@@ -48,5 +54,27 @@ class PayrollItemController extends BaseController<PayrollItemDto, UUID> {
     @Secured({ROLE_ADMIN, ROLE_HR_DIRECTOR, ROLE_MANAGER_HR})
     public ResponseEntity<PayrollItemDto> getOne(@PathVariable(value = "id") UUID id) {
         return super.getOne(id);
+    }
+
+    @Override
+    @PutMapping("/{id}")
+    @Secured({ROLE_ADMIN, ROLE_HR_DIRECTOR, ROLE_MANAGER_HR})
+    public ResponseEntity<PayrollItemDto> update(@PathVariable(value = "id") UUID id,
+            @Valid @RequestBody PayrollItemDto entity) {
+        return super.update(id, entity);
+    }
+
+    @Override
+    @PostMapping
+    @Secured({ROLE_ADMIN, ROLE_HR_DIRECTOR, ROLE_MANAGER_HR})
+    public ResponseEntity<PayrollItemDto> create(@Valid @RequestBody PayrollItemDto entity) {
+        return super.create(entity);
+    }
+
+    @Override
+    @DeleteMapping("/{id}")
+    @Secured({ROLE_ADMIN, ROLE_HR_DIRECTOR, ROLE_MANAGER_HR})
+    public ResponseEntity<PayrollItemDto> delete(@PathVariable(value = "id") UUID id) {
+        return super.delete(id);
     }
 }

--- a/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollItemDto.java
+++ b/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollItemDto.java
@@ -1,0 +1,43 @@
+package com.entropyteam.entropay.employees.payroll;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+import com.entropyteam.entropay.common.sensitiveInformation.EmployeeIdAware;
+import com.entropyteam.entropay.common.sensitiveInformation.SensitiveInformation;
+
+record PayrollItemDto(
+        UUID id,
+        UUID payrollRunId,
+        UUID employeeId,
+        String internalId,
+        String firstName,
+        String lastName,
+        UUID contractId,
+        String clientName,
+        String paymentPlatform,
+        String modality,
+        @SensitiveInformation BigDecimal baseSalary,
+        @SensitiveInformation BigDecimal proportionalSalary,
+        Integer countryWorkingHoursInMonth,
+        BigDecimal ptoHoursInMonth,
+        BigDecimal unpaidLeaveHoursInMonth,
+        @SensitiveInformation BigDecimal unpaidLeaveDeduction,
+        BigDecimal billableHoursInMonth,
+        BigDecimal overtimeHours,
+        @SensitiveInformation BigDecimal overtimeAmount,
+        @SensitiveInformation BigDecimal reimbursementsAmount,
+        @SensitiveInformation BigDecimal hardwareClawback,
+        @SensitiveInformation BigDecimal vacationCashout,
+        @SensitiveInformation BigDecimal adjustment,
+        @SensitiveInformation BigDecimal previousBalance,
+        String notes,
+        @SensitiveInformation BigDecimal totalAmount,
+        boolean isFinalSettlement,
+        String calculationError
+) implements EmployeeIdAware {
+
+    @Override
+    public UUID getEmployeeId() {
+        return employeeId;
+    }
+}

--- a/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollItemRepository.java
+++ b/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollItemRepository.java
@@ -1,0 +1,22 @@
+package com.entropyteam.entropay.employees.payroll;
+
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.Query;
+import com.entropyteam.entropay.common.BaseRepository;
+
+interface PayrollItemRepository extends BaseRepository<PayrollItem, UUID> {
+
+    /**
+     * Items for a run, with the employee eagerly fetched. The run detail maps every item to a DTO
+     * that reads employee fields (internalId, first/last name); fetching the employee here keeps
+     * that a single query instead of one lazy load per item.
+     */
+    @Query("""
+            SELECT i FROM PayrollItem i
+            JOIN FETCH i.employee
+            WHERE i.payrollRun.id = :payrollRunId
+              AND i.deleted = false
+            """)
+    List<PayrollItem> findAllByPayrollRunIdAndDeletedIsFalse(UUID payrollRunId);
+}

--- a/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollItemService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollItemService.java
@@ -1,0 +1,113 @@
+package com.entropyteam.entropay.employees.payroll;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+import com.entropyteam.entropay.common.BaseRepository;
+import com.entropyteam.entropay.common.BaseService;
+import com.entropyteam.entropay.common.ReactAdminMapper;
+import com.entropyteam.entropay.employees.models.Employee;
+
+@Service
+class PayrollItemService extends BaseService<PayrollItem, PayrollItemDto, UUID> {
+
+    private final PayrollItemRepository payrollItemRepository;
+    private final PayrollCalculatorService calculator;
+
+    public PayrollItemService(PayrollItemRepository payrollItemRepository,
+            PayrollCalculatorService calculator,
+            ReactAdminMapper reactAdminMapper) {
+        super(PayrollItem.class, reactAdminMapper);
+        this.payrollItemRepository = payrollItemRepository;
+        this.calculator = calculator;
+    }
+
+    @Override
+    protected BaseRepository<PayrollItem, UUID> getRepository() {
+        return payrollItemRepository;
+    }
+
+    /**
+     * Items can only be edited while the parent run is in DRAFT — once approved/closed they're a
+     * historical record.
+     */
+    @Override
+    @Transactional
+    public PayrollItemDto update(UUID id, PayrollItemDto dto) {
+        PayrollItem item = payrollItemRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Payroll item not found"));
+        if (item.getPayrollRun() == null || item.getPayrollRun().getStatus() != PayrollRunStatus.DRAFT) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Payroll item can only be edited while the run is in DRAFT");
+        }
+        item.setAdjustment(PayrollCalculatorService.nz(dto.adjustment()));
+        item.setPreviousBalance(PayrollCalculatorService.nz(dto.previousBalance()));
+        item.setNotes(dto.notes());
+        calculator.recomputeTotals(item);
+        return toDTO(payrollItemRepository.save(item));
+    }
+
+    @Override
+    public PayrollItemDto create(PayrollItemDto entity) {
+        throw new ResponseStatusException(HttpStatus.METHOD_NOT_ALLOWED,
+                "Payroll items are created by the run, not by the API");
+    }
+
+    @Override
+    public PayrollItemDto delete(UUID id) {
+        throw new ResponseStatusException(HttpStatus.METHOD_NOT_ALLOWED,
+                "Delete the payroll run instead of individual items");
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<PayrollItemDto> findOne(UUID id) {
+        return super.findOne(id);
+    }
+
+    @Override
+    protected PayrollItemDto toDTO(PayrollItem entity) {
+        Employee e = entity.getEmployee();
+        return new PayrollItemDto(
+                entity.getId(),
+                entity.getPayrollRun() != null ? entity.getPayrollRun().getId() : null,
+                e != null ? e.getId() : null,
+                e != null ? e.getInternalId() : null,
+                e != null ? e.getFirstName() : null,
+                e != null ? e.getLastName() : null,
+                entity.getContract() != null ? entity.getContract().getId() : null,
+                entity.getClientName(),
+                entity.getPaymentPlatform(),
+                entity.getModality() != null ? entity.getModality().name() : null,
+                entity.getBaseSalary(),
+                entity.getProportionalSalary(),
+                entity.getCountryWorkingHoursInMonth(),
+                entity.getPtoHoursInMonth(),
+                entity.getUnpaidLeaveHoursInMonth(),
+                entity.getUnpaidLeaveDeduction(),
+                entity.getBillableHoursInMonth(),
+                entity.getOvertimeHours(),
+                entity.getOvertimeAmount(),
+                entity.getReimbursementsAmount(),
+                entity.getHardwareClawback(),
+                entity.getVacationCashout(),
+                entity.getAdjustment(),
+                entity.getPreviousBalance(),
+                entity.getNotes(),
+                entity.getTotalAmount(),
+                entity.isFinalSettlement(),
+                entity.getCalculationError()
+        );
+    }
+
+    @Override
+    protected PayrollItem toEntity(PayrollItemDto dto) {
+        // Items are created by the orchestrator; this method only services the BaseService contract.
+        PayrollItem item = new PayrollItem();
+        item.setId(dto.id());
+        return item;
+    }
+}

--- a/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollOrchestratorService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollOrchestratorService.java
@@ -1,0 +1,77 @@
+package com.entropyteam.entropay.employees.payroll;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+/**
+ * Drives a payroll run end-to-end: the {@code @Async} entrypoint runs on the small dedicated
+ * {@code payrollDispatchExecutor}, loads context once, fans out the per-employee calculations
+ * across the separate {@code payrollExecutor}, then hands the results to {@link PayrollPersister}.
+ * Keeping dispatch and calculation on distinct pools avoids self-contention and queue overflow.
+ * Models the orchestration after {@code EmailLeakCheckService}'s {@code CompletableFuture.allOf(...)}
+ * pattern.
+ */
+@Service
+class PayrollOrchestratorService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PayrollOrchestratorService.class);
+
+    private final PayrollDataLoader dataLoader;
+    private final PayrollCalculatorService calculator;
+    private final PayrollPersister persister;
+    private final Executor payrollExecutor;
+
+    public PayrollOrchestratorService(PayrollDataLoader dataLoader,
+            PayrollCalculatorService calculator,
+            PayrollPersister persister,
+            @Qualifier("payrollExecutor") Executor payrollExecutor) {
+        this.dataLoader = dataLoader;
+        this.calculator = calculator;
+        this.persister = persister;
+        this.payrollExecutor = payrollExecutor;
+    }
+
+    @Async("payrollDispatchExecutor")
+    public CompletableFuture<UUID> startPayrollRun(UUID runId, LocalDate period) {
+        LOGGER.info("Payroll run {} starting for period {}", runId, period);
+        try {
+            PayrollContext ctx = dataLoader.loadContext(period);
+
+            List<CompletableFuture<PayrollItem>> futures = ctx.contracts().stream()
+                    .map(contract -> CompletableFuture.supplyAsync(
+                            () -> calculator.calculate(contract, ctx), payrollExecutor))
+                    .toList();
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+            List<PayrollItem> items = futures.stream().map(CompletableFuture::join).toList();
+            BigDecimal total = items.stream()
+                    .map(PayrollItem::getTotalAmount)
+                    .filter(java.util.Objects::nonNull)
+                    .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+            persister.persistRunResult(
+                    runId, items,
+                    total.setScale(2, RoundingMode.HALF_UP),
+                    items.size());
+
+            int erroredCount = (int) items.stream().filter(i -> i.getCalculationError() != null).count();
+            LOGGER.info("Payroll run {} completed: {} items, {} errored, total={}",
+                    runId, items.size(), erroredCount, total);
+            return CompletableFuture.completedFuture(runId);
+        } catch (RuntimeException e) {
+            LOGGER.error("Payroll run {} failed: {}", runId, e.getMessage(), e);
+            persister.persistRunFailure(runId, e.getClass().getSimpleName() + ": " + e.getMessage());
+            return CompletableFuture.failedFuture(e);
+        }
+    }
+}

--- a/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollPersister.java
+++ b/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollPersister.java
@@ -3,7 +3,10 @@ package com.entropyteam.entropay.employees.payroll;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,9 +14,16 @@ import org.springframework.transaction.annotation.Transactional;
  * Owns the database writes for the orchestrated payroll run. Keeping persistence in its own
  * Spring-managed bean lets {@link PayrollOrchestratorService} remain a non-transactional async
  * coordinator, sidestepping the self-invocation limitations of {@code @Async + @Transactional}.
+ *
+ * <p>Both write methods guard against the race where a run is soft-deleted (or otherwise transitions
+ * out of {@code RUNNING}) while the async orchestrator is still computing. Without the guard, the
+ * orchestrator would resurrect the deleted run by writing items + flipping its status. With it, a
+ * concurrent delete is honored: the late persist becomes a no-op and the run stays deleted.
  */
 @Service
 class PayrollPersister {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PayrollPersister.class);
 
     private final PayrollRunRepository payrollRunRepository;
     private final PayrollItemRepository payrollItemRepository;
@@ -27,7 +37,11 @@ class PayrollPersister {
     @Transactional
     public void persistRunResult(UUID runId, List<PayrollItem> items, BigDecimal total,
             int employeeCount) {
-        PayrollRun run = payrollRunRepository.findById(runId).orElseThrow();
+        Optional<PayrollRun> loaded = loadRunIfStillRunning(runId, "result");
+        if (loaded.isEmpty()) {
+            return;
+        }
+        PayrollRun run = loaded.get();
         items.forEach(i -> i.setPayrollRun(run));
         payrollItemRepository.saveAll(items);
         run.setStatus(PayrollRunStatus.DRAFT);
@@ -39,11 +53,31 @@ class PayrollPersister {
 
     @Transactional
     public void persistRunFailure(UUID runId, String errorMessage) {
-        PayrollRun run = payrollRunRepository.findById(runId).orElseThrow();
+        Optional<PayrollRun> loaded = loadRunIfStillRunning(runId, "failure");
+        if (loaded.isEmpty()) {
+            return;
+        }
+        PayrollRun run = loaded.get();
         run.setStatus(PayrollRunStatus.FAILED);
         run.setCompletedAt(Instant.now());
         run.setErrorMessage(truncate(errorMessage));
         payrollRunRepository.save(run);
+    }
+
+    private Optional<PayrollRun> loadRunIfStillRunning(UUID runId, String operation) {
+        Optional<PayrollRun> opt = payrollRunRepository.findById(runId);
+        if (opt.isEmpty()) {
+            LOGGER.warn("Payroll persist {} skipped: run {} no longer exists", operation, runId);
+            return Optional.empty();
+        }
+        PayrollRun run = opt.get();
+        if (run.isDeleted() || run.getStatus() != PayrollRunStatus.RUNNING) {
+            LOGGER.warn("Payroll persist {} skipped: run {} is no longer RUNNING "
+                            + "(status={}, deleted={}) — likely cancelled or swept",
+                    operation, runId, run.getStatus(), run.isDeleted());
+            return Optional.empty();
+        }
+        return Optional.of(run);
     }
 
     private static String truncate(String s) {

--- a/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollPersister.java
+++ b/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollPersister.java
@@ -1,0 +1,55 @@
+package com.entropyteam.entropay.employees.payroll;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Owns the database writes for the orchestrated payroll run. Keeping persistence in its own
+ * Spring-managed bean lets {@link PayrollOrchestratorService} remain a non-transactional async
+ * coordinator, sidestepping the self-invocation limitations of {@code @Async + @Transactional}.
+ */
+@Service
+class PayrollPersister {
+
+    private final PayrollRunRepository payrollRunRepository;
+    private final PayrollItemRepository payrollItemRepository;
+
+    public PayrollPersister(PayrollRunRepository payrollRunRepository,
+            PayrollItemRepository payrollItemRepository) {
+        this.payrollRunRepository = payrollRunRepository;
+        this.payrollItemRepository = payrollItemRepository;
+    }
+
+    @Transactional
+    public void persistRunResult(UUID runId, List<PayrollItem> items, BigDecimal total,
+            int employeeCount) {
+        PayrollRun run = payrollRunRepository.findById(runId).orElseThrow();
+        items.forEach(i -> i.setPayrollRun(run));
+        payrollItemRepository.saveAll(items);
+        run.setStatus(PayrollRunStatus.DRAFT);
+        run.setCompletedAt(Instant.now());
+        run.setTotalAmount(total);
+        run.setEmployeeCount(employeeCount);
+        payrollRunRepository.save(run);
+    }
+
+    @Transactional
+    public void persistRunFailure(UUID runId, String errorMessage) {
+        PayrollRun run = payrollRunRepository.findById(runId).orElseThrow();
+        run.setStatus(PayrollRunStatus.FAILED);
+        run.setCompletedAt(Instant.now());
+        run.setErrorMessage(truncate(errorMessage));
+        payrollRunRepository.save(run);
+    }
+
+    private static String truncate(String s) {
+        if (s == null) {
+            return null;
+        }
+        return s.length() <= 1990 ? s : s.substring(0, 1990) + "...";
+    }
+}

--- a/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollRun.java
+++ b/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollRun.java
@@ -1,0 +1,137 @@
+package com.entropyteam.entropay.employees.payroll;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import org.hibernate.annotations.SQLRestriction;
+import com.entropyteam.entropay.common.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+@Entity(name = "PayrollRun")
+@Table(name = "payroll_run")
+class PayrollRun extends BaseEntity {
+
+    @Column(nullable = false)
+    private LocalDate period;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PayrollRunStatus status;
+
+    @Column(name = "triggered_by_user_id")
+    private UUID triggeredByUserId;
+
+    @Column(name = "triggered_by_email")
+    private String triggeredByEmail;
+
+    @Column(name = "started_at")
+    private Instant startedAt;
+
+    @Column(name = "completed_at")
+    private Instant completedAt;
+
+    @Column(name = "error_message", length = 2000)
+    private String errorMessage;
+
+    @Column(name = "total_amount", precision = 14, scale = 2)
+    private BigDecimal totalAmount;
+
+    @Column(name = "employee_count")
+    private Integer employeeCount;
+
+    @OneToMany(mappedBy = "payrollRun")
+    @SQLRestriction("deleted = false")
+    private Set<PayrollItem> items = new HashSet<>();
+
+    public PayrollRun() {
+    }
+
+    public LocalDate getPeriod() {
+        return period;
+    }
+
+    public void setPeriod(LocalDate period) {
+        this.period = period;
+    }
+
+    public PayrollRunStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(PayrollRunStatus status) {
+        this.status = status;
+    }
+
+    public UUID getTriggeredByUserId() {
+        return triggeredByUserId;
+    }
+
+    public void setTriggeredByUserId(UUID triggeredByUserId) {
+        this.triggeredByUserId = triggeredByUserId;
+    }
+
+    public String getTriggeredByEmail() {
+        return triggeredByEmail;
+    }
+
+    public void setTriggeredByEmail(String triggeredByEmail) {
+        this.triggeredByEmail = triggeredByEmail;
+    }
+
+    public Instant getStartedAt() {
+        return startedAt;
+    }
+
+    public void setStartedAt(Instant startedAt) {
+        this.startedAt = startedAt;
+    }
+
+    public Instant getCompletedAt() {
+        return completedAt;
+    }
+
+    public void setCompletedAt(Instant completedAt) {
+        this.completedAt = completedAt;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public BigDecimal getTotalAmount() {
+        return totalAmount;
+    }
+
+    public void setTotalAmount(BigDecimal totalAmount) {
+        this.totalAmount = totalAmount;
+    }
+
+    public Integer getEmployeeCount() {
+        return employeeCount;
+    }
+
+    public void setEmployeeCount(Integer employeeCount) {
+        this.employeeCount = employeeCount;
+    }
+
+    public Set<PayrollItem> getItems() {
+        return items;
+    }
+
+    public void setItems(Set<PayrollItem> items) {
+        this.items = items;
+    }
+}

--- a/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollRunController.java
+++ b/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollRunController.java
@@ -1,0 +1,91 @@
+package com.entropyteam.entropay.employees.payroll;
+
+import static com.entropyteam.entropay.auth.AuthConstants.ROLE_ADMIN;
+import static com.entropyteam.entropay.auth.AuthConstants.ROLE_HR_DIRECTOR;
+import static com.entropyteam.entropay.auth.AuthConstants.ROLE_MANAGER_HR;
+
+import java.util.List;
+import java.util.UUID;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import com.entropyteam.entropay.common.BaseController;
+import com.entropyteam.entropay.common.ReactAdminParams;
+
+/**
+ * REST surface for payroll runs. Doesn't extend {@link BaseController} because the POST shape is a
+ * trigger DTO ({@link TriggerPayrollDto}), not the read DTO; the inherited approach would force the
+ * FE to send all the empty fields of {@link PayrollRunDto}.
+ */
+@RestController
+@CrossOrigin
+@RequestMapping(value = "/payroll-runs", produces = MediaType.APPLICATION_JSON_VALUE)
+@Secured({ROLE_ADMIN, ROLE_HR_DIRECTOR, ROLE_MANAGER_HR})
+class PayrollRunController {
+
+    private final PayrollRunService payrollRunService;
+    private final PayrollOrchestratorService orchestrator;
+
+    public PayrollRunController(PayrollRunService payrollRunService,
+            PayrollOrchestratorService orchestrator) {
+        this.payrollRunService = payrollRunService;
+        this.orchestrator = orchestrator;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<PayrollRunDto>> list(ReactAdminParams params) {
+        Page<PayrollRunDto> page = payrollRunService.findAllActive(params);
+        return ResponseEntity.ok()
+                .header(BaseController.X_TOTAL_COUNT, String.valueOf(page.getTotalElements()))
+                .body(page.getContent());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<PayrollRunDto> getOne(@PathVariable UUID id) {
+        return payrollRunService.findOne(id)
+                .map(ResponseEntity::ok)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Payroll run not found"));
+    }
+
+    /** Fire-and-forget. Returns 202 with the freshly-created run (status=RUNNING) for FE polling. */
+    @PostMapping
+    public ResponseEntity<PayrollRunDto> trigger(@Valid @RequestBody TriggerPayrollDto dto) {
+        PayrollRun run = payrollRunService.createRunForPeriod(dto);
+        orchestrator.startPayrollRun(run.getId(), run.getPeriod());
+        return ResponseEntity.status(HttpStatus.ACCEPTED)
+                .body(payrollRunService.findOne(run.getId()).orElseThrow());
+    }
+
+    @PutMapping("/{id}/approve")
+    public ResponseEntity<PayrollRunDto> approve(@PathVariable UUID id) {
+        return ResponseEntity.ok(payrollRunService.approve(id));
+    }
+
+    @PutMapping("/{id}/unapprove")
+    public ResponseEntity<PayrollRunDto> unapprove(@PathVariable UUID id) {
+        return ResponseEntity.ok(payrollRunService.unapprove(id));
+    }
+
+    @PutMapping("/{id}/close")
+    public ResponseEntity<PayrollRunDto> close(@PathVariable UUID id) {
+        return ResponseEntity.ok(payrollRunService.close(id));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<PayrollRunDto> delete(@PathVariable UUID id) {
+        return ResponseEntity.ok(payrollRunService.delete(id));
+    }
+}

--- a/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollRunDto.java
+++ b/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollRunDto.java
@@ -1,0 +1,23 @@
+package com.entropyteam.entropay.employees.payroll;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+record PayrollRunDto(
+        UUID id,
+        @JsonFormat(pattern = "yyyy-MM-dd") LocalDate period,
+        PayrollRunStatus status,
+        UUID triggeredByUserId,
+        String triggeredByEmail,
+        Instant startedAt,
+        Instant completedAt,
+        String errorMessage,
+        BigDecimal totalAmount,
+        Integer employeeCount,
+        List<PayrollItemDto> items
+) {
+}

--- a/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollRunRepository.java
+++ b/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollRunRepository.java
@@ -1,0 +1,16 @@
+package com.entropyteam.entropay.employees.payroll;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import com.entropyteam.entropay.common.BaseRepository;
+
+interface PayrollRunRepository extends BaseRepository<PayrollRun, UUID> {
+
+    Optional<PayrollRun> findByPeriodAndDeletedIsFalse(LocalDate period);
+
+    List<PayrollRun> findAllByPeriodAndStatusInAndDeletedIsFalse(LocalDate period, List<PayrollRunStatus> statuses);
+
+    List<PayrollRun> findAllByStatusAndDeletedIsFalse(PayrollRunStatus status);
+}

--- a/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollRunService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollRunService.java
@@ -58,10 +58,14 @@ class PayrollRunService extends BaseService<PayrollRun, PayrollRunDto, UUID> {
         if (existing.isPresent()) {
             PayrollRun current = existing.get();
             switch (current.getStatus()) {
-                case APPROVED, CLOSED -> throw new ResponseStatusException(
+                case APPROVED -> throw new ResponseStatusException(
                         HttpStatus.CONFLICT,
-                        "A " + current.getStatus() + " payroll run already exists for " + period
+                        "An APPROVED payroll run already exists for " + period
                                 + ". Un-approve it first if you need to re-run.");
+                case CLOSED -> throw new ResponseStatusException(
+                        HttpStatus.CONFLICT,
+                        "A CLOSED payroll run already exists for " + period
+                                + ". Closed runs can only be removed by an admin.");
                 case RUNNING -> throw new ResponseStatusException(
                         HttpStatus.CONFLICT,
                         "A payroll run is already in progress for " + period);
@@ -132,6 +136,15 @@ class PayrollRunService extends BaseService<PayrollRun, PayrollRunDto, UUID> {
     public PayrollRunDto delete(UUID runId) {
         PayrollRun run = payrollRunRepository.findById(runId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Payroll run not found"));
+        if (run.getStatus() == PayrollRunStatus.RUNNING) {
+            // Deleting a RUNNING run would race the async orchestrator's persist step. Even with
+            // PayrollPersister guarding against deleted/non-RUNNING runs, blocking here gives the
+            // user a clear answer instead of a silently dropped run. Wait for the run to finish
+            // (it will land in DRAFT or FAILED) and delete that.
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Cannot delete a payroll run while it is still RUNNING. "
+                            + "Wait for it to finish (DRAFT or FAILED) and try again.");
+        }
         boolean lockedStatus = run.getStatus() == PayrollRunStatus.APPROVED
                 || run.getStatus() == PayrollRunStatus.CLOSED;
         if (lockedStatus && AuthUtils.getUserRole() != AppRole.ROLE_ADMIN) {

--- a/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollRunService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollRunService.java
@@ -1,0 +1,235 @@
+package com.entropyteam.entropay.employees.payroll;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+import com.entropyteam.entropay.auth.AppRole;
+import com.entropyteam.entropay.auth.AuthUtils;
+import com.entropyteam.entropay.common.BaseRepository;
+import com.entropyteam.entropay.common.BaseService;
+import com.entropyteam.entropay.common.ReactAdminMapper;
+import com.entropyteam.entropay.common.ReactAdminParams;
+
+@Service
+class PayrollRunService extends BaseService<PayrollRun, PayrollRunDto, UUID> {
+
+    private final PayrollRunRepository payrollRunRepository;
+    private final PayrollItemRepository payrollItemRepository;
+    private final PayrollItemService payrollItemService;
+
+    public PayrollRunService(PayrollRunRepository payrollRunRepository,
+            PayrollItemRepository payrollItemRepository,
+            PayrollItemService payrollItemService,
+            ReactAdminMapper reactAdminMapper) {
+        super(PayrollRun.class, reactAdminMapper);
+        this.payrollRunRepository = payrollRunRepository;
+        this.payrollItemRepository = payrollItemRepository;
+        this.payrollItemService = payrollItemService;
+    }
+
+    @Override
+    protected BaseRepository<PayrollRun, UUID> getRepository() {
+        return payrollRunRepository;
+    }
+
+    /**
+     * Validate state, drop any prior DRAFT for the same period (cascade deletes its items), and
+     * create a new RUNNING run synchronously so the FE has an id to poll. The actual calculation
+     * happens asynchronously after this returns.
+     */
+    @Transactional
+    public PayrollRun createRunForPeriod(TriggerPayrollDto dto) {
+        LocalDate period = YearMonth.from(dto.period()).atDay(1);
+        Optional<PayrollRun> existing = payrollRunRepository.findByPeriodAndDeletedIsFalse(period);
+        if (existing.isPresent()) {
+            PayrollRun current = existing.get();
+            switch (current.getStatus()) {
+                case APPROVED, CLOSED -> throw new ResponseStatusException(
+                        HttpStatus.CONFLICT,
+                        "A " + current.getStatus() + " payroll run already exists for " + period
+                                + ". Un-approve it first if you need to re-run.");
+                case RUNNING -> throw new ResponseStatusException(
+                        HttpStatus.CONFLICT,
+                        "A payroll run is already in progress for " + period);
+                case DRAFT, FAILED -> deleteRunAndItems(current);
+            }
+        }
+        PayrollRun run = new PayrollRun();
+        run.setPeriod(period);
+        run.setStatus(PayrollRunStatus.RUNNING);
+        run.setStartedAt(Instant.now());
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth instanceof JwtAuthenticationToken jwtAuth) {
+            // auth.getName() is the `sub` claim (a UUID for Cognito); we want the human-readable email.
+            String email = jwtAuth.getToken().getClaimAsString("email");
+            if (email != null) {
+                run.setTriggeredByEmail(email);
+            } else {
+                run.setTriggeredByEmail(auth.getName());
+            }
+            try {
+                run.setTriggeredByUserId(UUID.fromString(jwtAuth.getToken().getSubject()));
+            } catch (IllegalArgumentException ignored) {
+                // sub isn't a UUID — leave triggeredByUserId null.
+            }
+        } else if (auth != null) {
+            run.setTriggeredByEmail(auth.getName());
+        }
+        // saveAndFlush + catch DataIntegrityViolationException to make the race-safe path produce a
+        // clean 409: two concurrent POSTs for the same period would both pass the existence check
+        // above and both INSERT; one then hits idx_payroll_run_period_unique_active. With save() the
+        // violation surfaces at commit (outside this method) as a 500. saveAndFlush forces it here.
+        try {
+            return payrollRunRepository.saveAndFlush(run);
+        } catch (DataIntegrityViolationException e) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "A payroll run already exists for " + period);
+        }
+    }
+
+    @Transactional
+    public PayrollRunDto approve(UUID runId) {
+        return transition(runId, PayrollRunStatus.DRAFT, PayrollRunStatus.APPROVED);
+    }
+
+    @Transactional
+    public PayrollRunDto close(UUID runId) {
+        return transition(runId, PayrollRunStatus.APPROVED, PayrollRunStatus.CLOSED);
+    }
+
+    @Transactional
+    public PayrollRunDto unapprove(UUID runId) {
+        return transition(runId, PayrollRunStatus.APPROVED, PayrollRunStatus.DRAFT);
+    }
+
+    private PayrollRunDto transition(UUID runId, PayrollRunStatus from, PayrollRunStatus to) {
+        PayrollRun run = payrollRunRepository.findById(runId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Payroll run not found"));
+        if (run.getStatus() != from) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Cannot transition from " + run.getStatus() + " to " + to);
+        }
+        run.setStatus(to);
+        return toDTO(payrollRunRepository.save(run));
+    }
+
+    @Override
+    @Transactional
+    public PayrollRunDto delete(UUID runId) {
+        PayrollRun run = payrollRunRepository.findById(runId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Payroll run not found"));
+        boolean lockedStatus = run.getStatus() == PayrollRunStatus.APPROVED
+                || run.getStatus() == PayrollRunStatus.CLOSED;
+        if (lockedStatus && AuthUtils.getUserRole() != AppRole.ROLE_ADMIN) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Cannot delete a " + run.getStatus() + " payroll run; un-approve it first.");
+        }
+        deleteRunAndItems(run);
+        return toDTO(run);
+    }
+
+    private void deleteRunAndItems(PayrollRun run) {
+        payrollItemRepository.findAllByPayrollRunIdAndDeletedIsFalse(run.getId())
+                .forEach(i -> i.setDeleted(true));
+        run.setDeleted(true);
+        // Flush so the soft-delete UPDATE hits the DB before any subsequent INSERT for the same
+        // period. Hibernate's default ActionQueue runs INSERTs before UPDATEs at commit, which
+        // would otherwise violate idx_payroll_run_period_unique_active when re-running a period.
+        payrollRunRepository.saveAndFlush(run);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<PayrollRunDto> findAllActive(ReactAdminParams params) {
+        Page<PayrollRunDto> page = super.findAllActive(params);
+        // Don't eagerly load items into the list response — the detail endpoint does that.
+        List<PayrollRunDto> stripped = page.getContent().stream()
+                .map(this::stripItems)
+                .toList();
+        return new PageImpl<>(stripped, Pageable.unpaged(), page.getTotalElements());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<PayrollRunDto> findOne(UUID id) {
+        return payrollRunRepository.findById(id).map(this::toDTOWithItems);
+    }
+
+    private PayrollRunDto stripItems(PayrollRunDto dto) {
+        return new PayrollRunDto(dto.id(), dto.period(), dto.status(),
+                dto.triggeredByUserId(), dto.triggeredByEmail(), dto.startedAt(), dto.completedAt(),
+                dto.errorMessage(), dto.totalAmount(), dto.employeeCount(), List.of());
+    }
+
+    @Override
+    protected PayrollRunDto toDTO(PayrollRun entity) {
+        return new PayrollRunDto(
+                entity.getId(),
+                entity.getPeriod(),
+                entity.getStatus(),
+                entity.getTriggeredByUserId(),
+                entity.getTriggeredByEmail(),
+                entity.getStartedAt(),
+                entity.getCompletedAt(),
+                entity.getErrorMessage(),
+                entity.getTotalAmount(),
+                entity.getEmployeeCount(),
+                List.of()
+        );
+    }
+
+    PayrollRunDto toDTOWithItems(PayrollRun entity) {
+        List<PayrollItemDto> items = payrollItemRepository
+                .findAllByPayrollRunIdAndDeletedIsFalse(entity.getId())
+                .stream()
+                .map(payrollItemService::toDTO)
+                .toList();
+        return new PayrollRunDto(
+                entity.getId(),
+                entity.getPeriod(),
+                entity.getStatus(),
+                entity.getTriggeredByUserId(),
+                entity.getTriggeredByEmail(),
+                entity.getStartedAt(),
+                entity.getCompletedAt(),
+                entity.getErrorMessage(),
+                entity.getTotalAmount(),
+                entity.getEmployeeCount(),
+                items
+        );
+    }
+
+    @Override
+    protected PayrollRun toEntity(PayrollRunDto dto) {
+        // Runs aren't created via generic CRUD — only via createRunForPeriod.
+        PayrollRun run = new PayrollRun();
+        run.setId(dto.id());
+        return run;
+    }
+
+    @Override
+    public PayrollRunDto create(PayrollRunDto entity) {
+        throw new ResponseStatusException(HttpStatus.METHOD_NOT_ALLOWED,
+                "Use POST /payroll-runs with TriggerPayrollDto to start a run");
+    }
+
+    @Override
+    public PayrollRunDto update(UUID id, PayrollRunDto entity) {
+        throw new ResponseStatusException(HttpStatus.METHOD_NOT_ALLOWED,
+                "Payroll runs are not editable in place; use /approve, /close, or DELETE");
+    }
+}

--- a/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollRunStatus.java
+++ b/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollRunStatus.java
@@ -1,0 +1,9 @@
+package com.entropyteam.entropay.employees.payroll;
+
+enum PayrollRunStatus {
+    RUNNING,
+    FAILED,
+    DRAFT,
+    APPROVED,
+    CLOSED
+}

--- a/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollStaleRunSweeper.java
+++ b/src/main/java/com/entropyteam/entropay/employees/payroll/PayrollStaleRunSweeper.java
@@ -1,0 +1,71 @@
+package com.entropyteam.entropay.employees.payroll;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * On application startup, marks orphaned payroll runs as FAILED.
+ *
+ * <p>If the JVM restarts mid-run, the {@code payroll_run} row stays {@code RUNNING} forever, and
+ * {@link PayrollRunService#createRunForPeriod} then rejects that period permanently with 409.
+ * This sweeper transitions such rows to {@code FAILED} so the period can be re-run.
+ *
+ * <p>The service can run as multiple ECS instances: another instance may legitimately be mid-run
+ * when this one starts. To avoid failing a healthy concurrent run, only runs whose
+ * {@code startedAt} is older than a configurable threshold (default ~1 hour) are swept.
+ */
+@Component
+class PayrollStaleRunSweeper {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PayrollStaleRunSweeper.class);
+
+    private final PayrollRunRepository payrollRunRepository;
+    private final long thresholdMinutes;
+
+    public PayrollStaleRunSweeper(PayrollRunRepository payrollRunRepository,
+            @Value("${payroll.stale-run.threshold-minutes:60}") long thresholdMinutes) {
+        this.payrollRunRepository = payrollRunRepository;
+        this.thresholdMinutes = thresholdMinutes;
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    @Transactional
+    public void sweepStaleRunningRuns() {
+        Instant cutoff = Instant.now().minus(thresholdMinutes, ChronoUnit.MINUTES);
+        List<PayrollRun> runningRuns =
+                payrollRunRepository.findAllByStatusAndDeletedIsFalse(PayrollRunStatus.RUNNING);
+
+        int swept = 0;
+        for (PayrollRun run : runningRuns) {
+            Instant startedAt = run.getStartedAt();
+            // Skip runs without a startedAt or that started recently — another ECS instance may
+            // legitimately still be processing them.
+            if (startedAt == null || startedAt.isAfter(cutoff)) {
+                continue;
+            }
+            run.setStatus(PayrollRunStatus.FAILED);
+            run.setCompletedAt(Instant.now());
+            run.setErrorMessage("Run was still RUNNING after a server restart and exceeded the "
+                    + thresholdMinutes + "-minute stale threshold; marked FAILED by the startup "
+                    + "sweep. Re-trigger the payroll run for this period.");
+            payrollRunRepository.save(run);
+            swept++;
+            LOGGER.warn("Stale payroll run {} (period {}, startedAt {}) marked FAILED by startup sweep",
+                    run.getId(), run.getPeriod(), startedAt);
+        }
+
+        if (swept > 0) {
+            LOGGER.info("Payroll startup sweep marked {} stale RUNNING run(s) as FAILED", swept);
+        } else {
+            LOGGER.debug("Payroll startup sweep found no stale RUNNING runs");
+        }
+    }
+}

--- a/src/main/java/com/entropyteam/entropay/employees/payroll/TriggerPayrollDto.java
+++ b/src/main/java/com/entropyteam/entropay/employees/payroll/TriggerPayrollDto.java
@@ -1,0 +1,13 @@
+package com.entropyteam.entropay.employees.payroll;
+
+import java.time.LocalDate;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Inputs the FE provides when launching a payroll run. Today every entropista is paid in USD,
+ * so the target period is the only thing the run needs.
+ */
+record TriggerPayrollDto(
+        @NotNull LocalDate period
+) {
+}

--- a/src/main/java/com/entropyteam/entropay/employees/repositories/AssignmentRepository.java
+++ b/src/main/java/com/entropyteam/entropay/employees/repositories/AssignmentRepository.java
@@ -1,6 +1,7 @@
 package com.entropyteam.entropay.employees.repositories;
 
 import java.time.LocalDate;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -52,6 +53,26 @@ public interface AssignmentRepository extends BaseRepository<Assignment, UUID> {
     List<Assignment> findAllAssignmentsByClientIdIn(@Param("clientIds") List<UUID> clientIds);
 
     List<Assignment> findAllByEmployeeIdInAndDeletedIsFalse(List<UUID> employeesId);
+
+    /**
+     * For payroll context loading: active assignments overlapping the payroll period, joined to
+     * project + client so the calculator can resolve the per-item client name without lazy-loading
+     * {@code Employee.assignments} from worker threads.
+     */
+    @Query("""
+            SELECT a FROM Assignment a
+            LEFT JOIN FETCH a.project p
+            LEFT JOIN FETCH p.client
+            WHERE a.employee.id IN :employeeIds
+              AND a.deleted = false
+              AND a.active = true
+              AND (a.startDate IS NULL OR a.startDate <= :periodEnd)
+              AND (a.endDate IS NULL OR a.endDate >= :periodStart)
+            """)
+    List<Assignment> findActiveByEmployeeIdInOverlappingPeriod(
+            @Param("employeeIds") Collection<UUID> employeeIds,
+            @Param("periodStart") LocalDate periodStart,
+            @Param("periodEnd") LocalDate periodEnd);
 
     /**
      * This query is used for the Billing. Therefore, we are only including assignments that are full time or part

--- a/src/main/java/com/entropyteam/entropay/employees/repositories/ContractRepository.java
+++ b/src/main/java/com/entropyteam/entropay/employees/repositories/ContractRepository.java
@@ -1,6 +1,7 @@
 package com.entropyteam.entropay.employees.repositories;
 
 import java.time.LocalDate;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -33,4 +34,41 @@ public interface ContractRepository extends BaseRepository<Contract, UUID> {
               AND c.deleted = false
             """)
     List<Contract> findAllBetweenPeriod(LocalDate startDate, LocalDate endDate);
+
+    /**
+     * For payroll: contracts whose date range overlaps the period AND that are either currently
+     * active OR ended within the period (final settlement scenario — inactive contracts whose
+     * endDate falls in the month still need to be paid out for the days actually worked).
+     *
+     * Inactive contracts with no endDate or with endDate outside the period are excluded — they're
+     * historical records that should not be liquidated. Excludes soft-deleted employees too.
+     */
+    @Query(value = """
+            SELECT DISTINCT c FROM Contract c
+            JOIN FETCH c.employee e
+            LEFT JOIN FETCH e.country
+            JOIN FETCH c.paymentsSettlement
+            WHERE c.startDate <= :periodEnd
+              AND (c.endDate IS NULL OR c.endDate >= :periodStart)
+              AND c.deleted = false
+              AND e.deleted = false
+              AND (c.active = true
+                   OR (c.endDate IS NOT NULL
+                       AND c.endDate BETWEEN :periodStart AND :periodEnd))
+            """)
+    List<Contract> findAllOverlappingPeriodForPayroll(LocalDate periodStart, LocalDate periodEnd);
+
+    /**
+     * For payroll's hardware-clawback rule: hire date per employee, defined as the earliest
+     * non-deleted contract start. Pre-loaded into PayrollContext so the calculator never has to
+     * touch the Employee.contracts lazy collection from a thread without a Hibernate session.
+     */
+    @Query("""
+            SELECT c.employee.id, MIN(c.startDate)
+            FROM Contract c
+            WHERE c.employee.id IN :employeeIds
+              AND c.deleted = false
+            GROUP BY c.employee.id
+            """)
+    List<Object[]> findEarliestStartDateByEmployeeIds(@Param("employeeIds") Collection<UUID> employeeIds);
 }

--- a/src/main/java/com/entropyteam/entropay/employees/repositories/OvertimeRepository.java
+++ b/src/main/java/com/entropyteam/entropay/employees/repositories/OvertimeRepository.java
@@ -11,4 +11,6 @@ import com.entropyteam.entropay.employees.models.Overtime;
 public interface OvertimeRepository extends BaseRepository<Overtime, UUID> {
 
     List<Overtime> findByDateBetween(final LocalDate startDate, final LocalDate endDate);
+
+    List<Overtime> findByDateBetweenAndDeletedIsFalse(final LocalDate startDate, final LocalDate endDate);
 }

--- a/src/main/java/com/entropyteam/entropay/employees/repositories/PaymentInformationRepository.java
+++ b/src/main/java/com/entropyteam/entropay/employees/repositories/PaymentInformationRepository.java
@@ -1,11 +1,14 @@
 package com.entropyteam.entropay.employees.repositories;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import com.entropyteam.entropay.common.BaseRepository;
 import com.entropyteam.entropay.employees.models.PaymentInformation;
 
 public interface PaymentInformationRepository extends BaseRepository<PaymentInformation, UUID>{
-   
+
     List<PaymentInformation> findAllByEmployeeIdAndDeletedIsFalse(UUID id);
+
+    List<PaymentInformation> findAllByEmployeeIdInAndDeletedIsFalse(Collection<UUID> employeeIds);
 }

--- a/src/main/java/com/entropyteam/entropay/employees/repositories/PtoRepository.java
+++ b/src/main/java/com/entropyteam/entropay/employees/repositories/PtoRepository.java
@@ -37,7 +37,7 @@ public interface PtoRepository extends BaseRepository<Pto, UUID> {
     @Query(value = """
             FROM Pto p
             JOIN FETCH p.employee e
-            JOIN FETCH p.leaveType lt
+            LEFT JOIN FETCH p.leaveType lt
             WHERE (p.startDate <= :endDate and p.endDate >= :startDate)
                 AND p.status = 'APPROVED'
                 AND p.deleted = FALSE

--- a/src/main/java/com/entropyteam/entropay/employees/repositories/ReimbursementRepository.java
+++ b/src/main/java/com/entropyteam/entropay/employees/repositories/ReimbursementRepository.java
@@ -1,8 +1,20 @@
 package com.entropyteam.entropay.employees.repositories;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
+import org.springframework.data.jpa.repository.Query;
 import com.entropyteam.entropay.common.BaseRepository;
 import com.entropyteam.entropay.employees.models.Reimbursement;
 
 public interface ReimbursementRepository extends BaseRepository<Reimbursement, UUID> {
+
+    @Query("""
+            SELECT r FROM Reimbursement r
+            JOIN FETCH r.category
+            JOIN FETCH r.employee
+            WHERE r.date BETWEEN :startDate AND :endDate
+              AND r.deleted = false
+            """)
+    List<Reimbursement> findAllBetweenPeriod(LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/entropyteam/entropay/employees/repositories/VacationRepository.java
+++ b/src/main/java/com/entropyteam/entropay/employees/repositories/VacationRepository.java
@@ -1,5 +1,6 @@
 package com.entropyteam.entropay.employees.repositories;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.Query;
@@ -9,6 +10,8 @@ import com.entropyteam.entropay.employees.models.Vacation;
 import com.entropyteam.entropay.employees.repositories.projections.VacationBalanceByYear;
 
 public interface VacationRepository extends BaseRepository<Vacation, UUID> {
+
+    List<Vacation> findAllByEmployeeIdInAndDeletedIsFalse(Collection<UUID> employeeIds);
 
     @Query(value = "SELECT year, CAST((SUM(credit) - COALESCE(SUM(debit), 0)) AS int) AS balance "
             + " FROM Vacation WHERE employee_id = :employeeId AND deleted = false "

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -64,3 +64,8 @@ leakcheck.rate-limit.refresh-period=400
 leakcheck.executor.core-pool-size=1
 leakcheck.executor.max-pool-size=1
 leakcheck.executor.queue-capacity=500
+
+# Payroll Async Executor
+payroll.executor.core-pool-size=4
+payroll.executor.max-pool-size=8
+payroll.executor.queue-capacity=100

--- a/src/main/resources/db/migration/V87.0__DDL_create_payroll_run_tables.sql
+++ b/src/main/resources/db/migration/V87.0__DDL_create_payroll_run_tables.sql
@@ -1,0 +1,83 @@
+-- Payroll run header: one per (period, attempt). Items are calculated per active employee in that period.
+CREATE TABLE IF NOT EXISTS payroll_run (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    period DATE NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    triggered_by_user_id UUID,
+    triggered_by_email VARCHAR(255),
+    started_at TIMESTAMP,
+    completed_at TIMESTAMP,
+    error_message VARCHAR(2000),
+    total_amount NUMERIC(14, 2),
+    employee_count INTEGER,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    modified_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+-- One non-deleted run per period (re-running deletes the prior DRAFT before insert).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_payroll_run_period_unique_active
+    ON payroll_run(period) WHERE deleted = FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_payroll_run_status ON payroll_run(status);
+CREATE INDEX IF NOT EXISTS idx_payroll_run_deleted ON payroll_run(deleted);
+
+CREATE TABLE IF NOT EXISTS payroll_item (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    payroll_run_id UUID NOT NULL,
+    employee_id UUID NOT NULL,
+    contract_id UUID,
+    client_name VARCHAR(255),
+    payment_platform VARCHAR(100),
+    modality VARCHAR(20),
+    base_salary NUMERIC(14, 2) NOT NULL DEFAULT 0,
+    proportional_salary NUMERIC(14, 2) NOT NULL DEFAULT 0,
+    country_working_hours_in_month INTEGER,
+    pto_hours_in_month NUMERIC(8, 2) NOT NULL DEFAULT 0,
+    unpaid_leave_hours_in_month NUMERIC(8, 2) NOT NULL DEFAULT 0,
+    unpaid_leave_deduction NUMERIC(14, 2) NOT NULL DEFAULT 0,
+    billable_hours_in_month NUMERIC(8, 2) NOT NULL DEFAULT 0,
+    overtime_hours NUMERIC(8, 2) NOT NULL DEFAULT 0,
+    overtime_amount NUMERIC(14, 2) NOT NULL DEFAULT 0,
+    reimbursements_amount NUMERIC(14, 2) NOT NULL DEFAULT 0,
+    hardware_clawback NUMERIC(14, 2) NOT NULL DEFAULT 0,
+    vacation_cashout NUMERIC(14, 2) NOT NULL DEFAULT 0,
+    adjustment NUMERIC(14, 2) NOT NULL DEFAULT 0,
+    previous_balance NUMERIC(14, 2) NOT NULL DEFAULT 0,
+    notes VARCHAR(1000),
+    total_amount NUMERIC(14, 2) NOT NULL DEFAULT 0,
+    is_final_settlement BOOLEAN NOT NULL DEFAULT FALSE,
+    calculation_error VARCHAR(2000),
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    modified_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted BOOLEAN NOT NULL DEFAULT FALSE,
+    CONSTRAINT fk_payroll_item_run FOREIGN KEY (payroll_run_id) REFERENCES payroll_run(id) ON DELETE CASCADE,
+    CONSTRAINT fk_payroll_item_employee FOREIGN KEY (employee_id) REFERENCES employee(id),
+    CONSTRAINT fk_payroll_item_contract FOREIGN KEY (contract_id) REFERENCES contract(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_payroll_item_run ON payroll_item(payroll_run_id);
+CREATE INDEX IF NOT EXISTS idx_payroll_item_employee ON payroll_item(employee_id);
+CREATE INDEX IF NOT EXISTS idx_payroll_item_deleted ON payroll_item(deleted);
+
+-- Append payroll permissions for the three roles that should see the screen. Using jsonb || avoids
+-- having to re-emit the entire permissions array (V82-style) and so won't clobber unrelated entries
+-- added by other migrations or by hand.
+UPDATE public.config
+SET permissions = (permissions::jsonb || '[
+    {"entity": "payroll-runs", "actions": ["create", "read", "update", "delete"]},
+    {"entity": "payroll-items", "actions": ["read", "update"]}
+]'::jsonb)::json
+WHERE role IN ('ROLE_ADMIN', 'ROLE_MANAGER/HR', 'ROLE_HR_DIRECTOR');
+
+-- Append the Payroll menu entry. Key 12 is past the highest current top-level key (11 = Skills under ADMIN).
+UPDATE public.config
+SET menu = (menu::jsonb || '[
+    {
+      "name": "Payroll",
+      "href": "/#/payroll-runs",
+      "icon": "payroll-runs",
+      "key": 12
+    }
+]'::jsonb)::json
+WHERE role IN ('ROLE_ADMIN', 'ROLE_MANAGER/HR', 'ROLE_HR_DIRECTOR');

--- a/src/test/java/com/entropyteam/entropay/employees/payroll/PayrollCalculatorServiceTest.java
+++ b/src/test/java/com/entropyteam/entropay/employees/payroll/PayrollCalculatorServiceTest.java
@@ -1,0 +1,666 @@
+package com.entropyteam.entropay.employees.payroll;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import com.entropyteam.entropay.employees.models.Contract;
+import com.entropyteam.entropay.employees.models.Country;
+import com.entropyteam.entropay.employees.models.Currency;
+import com.entropyteam.entropay.employees.models.Employee;
+import com.entropyteam.entropay.employees.models.LeaveType;
+import com.entropyteam.entropay.employees.models.Modality;
+import com.entropyteam.entropay.employees.models.Overtime;
+import com.entropyteam.entropay.employees.models.PaymentSettlement;
+import com.entropyteam.entropay.employees.models.Pto;
+import com.entropyteam.entropay.employees.models.Reimbursement;
+import com.entropyteam.entropay.employees.models.ReimbursementCategory;
+import com.entropyteam.entropay.employees.models.Status;
+import com.entropyteam.entropay.employees.models.Vacation;
+
+class PayrollCalculatorServiceTest {
+
+    private static final LocalDate PERIOD = LocalDate.of(2026, 4, 1);
+    private static final int APRIL_2026_BUSINESS_DAYS_NO_HOLIDAYS = 22;
+    private static final int APRIL_2026_BUSINESS_HOURS_NO_HOLIDAYS = APRIL_2026_BUSINESS_DAYS_NO_HOLIDAYS * 8;
+
+    private PayrollCalculatorService calculator;
+    private Country argentina;
+    private UUID argentinaId;
+
+    @BeforeEach
+    void setUp() {
+        calculator = new PayrollCalculatorService();
+        argentina = new Country();
+        argentinaId = UUID.randomUUID();
+        argentina.setId(argentinaId);
+        argentina.setName("Argentina");
+    }
+
+    // -- Sueldo base / proporcional MONTHLY ----------------------------------------------------
+
+    @Test
+    @DisplayName("MONTHLY contract covering the full month → baseSalary equals contract salary, no proportional")
+    void monthlyFullMonth() {
+        Contract contract = monthlyContract("4250.00", LocalDate.of(2024, 1, 1), null);
+        var ctx = ctxFor(contract);
+
+        PayrollItem item = calculator.calculate(contract, ctx.build());
+
+        assertThat(item.getCalculationError()).isNull();
+        assertThat(item.getBaseSalary()).isEqualByComparingTo("4250.00");
+        assertThat(item.getProportionalSalary()).isEqualByComparingTo("0");
+        assertThat(item.isFinalSettlement()).isFalse();
+    }
+
+    @Test
+    @DisplayName("MONTHLY contract starting mid-month → proportional = (salary / 21.6) * workedBusinessDays")
+    void monthlyStartingMidMonth() {
+        // Starts Apr 15 (Wednesday) → worked days = 12 business days (Apr 15-30 excluding weekends).
+        Contract contract = monthlyContract("4400.00", LocalDate.of(2026, 4, 15), null);
+        var ctx = ctxFor(contract);
+
+        PayrollItem item = calculator.calculate(contract, ctx.build());
+
+        // Daily rate = 4400 / 21.6 = 203.7037; * 12 = 2444.4444 → 2444.44
+        assertThat(item.getBaseSalary()).isEqualByComparingTo("0");
+        assertThat(item.getProportionalSalary()).isEqualByComparingTo("2444.44");
+        assertThat(item.isFinalSettlement()).isFalse();
+    }
+
+    @Test
+    @DisplayName("MONTHLY proportional with a holiday inside the worked range → holiday is paid, total unchanged")
+    void monthlyProportionalHolidayIsPaid() {
+        // Starts Apr 15 → 12 weekdays Apr 15-30. Apr 20 is a holiday but should still be paid.
+        Contract contract = monthlyContract("4400.00", LocalDate.of(2026, 4, 15), null);
+        var ctx = ctxFor(contract).withHoliday(argentinaId, LocalDate.of(2026, 4, 20));
+
+        PayrollItem item = calculator.calculate(contract, ctx.build());
+
+        // Same as no-holiday case: 12 weekdays * (4400/21.6) = 2444.44.
+        assertThat(item.getProportionalSalary()).isEqualByComparingTo("2444.44");
+    }
+
+    @Test
+    @DisplayName("MONTHLY contract ending mid-month → proportional + isFinalSettlement true")
+    void monthlyEndingMidMonth() {
+        // Ends Apr 10 (Friday) → worked days = 8 business days (Apr 1-10 mon-fri).
+        Contract contract = monthlyContract("4400.00", LocalDate.of(2024, 1, 1), LocalDate.of(2026, 4, 10));
+        var ctx = ctxFor(contract);
+
+        PayrollItem item = calculator.calculate(contract, ctx.build());
+
+        // Daily rate = 4400 / 21.6 = 203.7037; * 8 = 1629.6296 → 1629.63
+        assertThat(item.getProportionalSalary()).isEqualByComparingTo("1629.63");
+        assertThat(item.isFinalSettlement()).isTrue();
+    }
+
+    @Test
+    @DisplayName("MONTHLY contract starting and ending in the same month → proportional covers only the worked range")
+    void monthlyStartingAndEndingSameMonth() {
+        // Apr 7 (Tue) to Apr 18 (Sat) → business days Apr 7-17 (Mon-Fri) = 9 days.
+        Contract contract = monthlyContract("4400.00", LocalDate.of(2026, 4, 7), LocalDate.of(2026, 4, 18));
+        var ctx = ctxFor(contract);
+
+        PayrollItem item = calculator.calculate(contract, ctx.build());
+
+        // Daily rate = 4400 / 21.6 = 203.7037; * 9 = 1833.3333 → 1833.33
+        assertThat(item.getProportionalSalary()).isEqualByComparingTo("1833.33");
+        assertThat(item.isFinalSettlement()).isTrue();
+    }
+
+    // -- Horas billables HOUR ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("HOUR contract full month in AR with no PTO → billable hours = country working hours")
+    void hourlyFullMonthNoPto() {
+        Contract contract = hourlyContract("30.00", LocalDate.of(2024, 1, 1), null);
+        var ctx = ctxFor(contract);
+
+        PayrollItem item = calculator.calculate(contract, ctx.build());
+
+        assertThat(item.getBillableHoursInMonth()).isEqualByComparingTo(BigDecimal.valueOf(APRIL_2026_BUSINESS_HOURS_NO_HOLIDAYS));
+        assertThat(item.getBaseSalary()).isEqualByComparingTo(new BigDecimal("30").multiply(BigDecimal.valueOf(APRIL_2026_BUSINESS_HOURS_NO_HOLIDAYS)));
+    }
+
+    @Test
+    @DisplayName("HOUR contract with one full PTO day → billable hours reduced by 8")
+    void hourlyWithOneFullDayPto() {
+        Contract contract = hourlyContract("30.00", LocalDate.of(2024, 1, 1), null);
+        Pto pto = pto(LocalDate.of(2026, 4, 8), LocalDate.of(2026, 4, 8), 1.0, null);
+        var ctx = ctxFor(contract).withPtos(contract.getEmployee().getId(), List.of(pto));
+
+        PayrollItem item = calculator.calculate(contract, ctx.build());
+
+        assertThat(item.getPtoHoursInMonth()).isEqualByComparingTo("8");
+        assertThat(item.getBillableHoursInMonth())
+                .isEqualByComparingTo(BigDecimal.valueOf(APRIL_2026_BUSINESS_HOURS_NO_HOLIDAYS - 8));
+    }
+
+    @Test
+    @DisplayName("HOUR contract with half-day PTO → billable hours reduced by 4")
+    void hourlyWithHalfDayPto() {
+        Contract contract = hourlyContract("30.00", LocalDate.of(2024, 1, 1), null);
+        Pto pto = pto(LocalDate.of(2026, 4, 8), LocalDate.of(2026, 4, 8), 0.5, null);
+        var ctx = ctxFor(contract).withPtos(contract.getEmployee().getId(), List.of(pto));
+
+        PayrollItem item = calculator.calculate(contract, ctx.build());
+
+        assertThat(item.getPtoHoursInMonth()).isEqualByComparingTo("4");
+        assertThat(item.getBillableHoursInMonth())
+                .isEqualByComparingTo(BigDecimal.valueOf(APRIL_2026_BUSINESS_HOURS_NO_HOLIDAYS - 4));
+    }
+
+    @Test
+    @DisplayName("PTO with labourHours set and fully in month → labourHours preferred over days*8")
+    void hourlyWithPtoLabourHoursPreferred() {
+        Contract contract = hourlyContract("30.00", LocalDate.of(2024, 1, 1), null);
+        // 2 days but labourHours says 14 (e.g. 7-hour days). Should use 14, not 16.
+        Pto pto = pto(LocalDate.of(2026, 4, 8), LocalDate.of(2026, 4, 9), 2.0, 14);
+        var ctx = ctxFor(contract).withPtos(contract.getEmployee().getId(), List.of(pto));
+
+        PayrollItem item = calculator.calculate(contract, ctx.build());
+
+        assertThat(item.getPtoHoursInMonth()).isEqualByComparingTo("14");
+    }
+
+    @Test
+    @DisplayName("PTO spanning month boundary → only hours within the target month are counted")
+    void hourlyWithPtoSpanningMonthBoundary() {
+        Contract contract = hourlyContract("30.00", LocalDate.of(2024, 1, 1), null);
+        // PTO Mar 30 (Mon) - Apr 3 (Fri) = 5 business days, only Apr 1 (Wed), 2 (Thu), 3 (Fri) fall in target month → 3*8=24.
+        // labourHours unset so we fall through to business-day arithmetic.
+        Pto pto = pto(LocalDate.of(2026, 3, 30), LocalDate.of(2026, 4, 3), 5.0, null);
+        var ctx = ctxFor(contract).withPtos(contract.getEmployee().getId(), List.of(pto));
+
+        PayrollItem item = calculator.calculate(contract, ctx.build());
+
+        assertThat(item.getPtoHoursInMonth()).isEqualByComparingTo("24");
+    }
+
+    @Test
+    @DisplayName("HOUR contract in country with mid-month holiday → billable hours exclude the holiday")
+    void hourlyWithMidMonthHoliday() {
+        Contract contract = hourlyContract("30.00", LocalDate.of(2024, 1, 1), null);
+        // Apr 8 (Wed) is a holiday for AR.
+        var ctx = ctxFor(contract).withHoliday(argentinaId, LocalDate.of(2026, 4, 8));
+
+        PayrollItem item = calculator.calculate(contract, ctx.build());
+
+        assertThat(item.getCountryWorkingHoursInMonth())
+                .isEqualTo(APRIL_2026_BUSINESS_HOURS_NO_HOLIDAYS - 8);
+    }
+
+    @Test
+    @DisplayName("PTO covering the entire month → billable hours floored at zero (never negative)")
+    void hourlyWithPtoCoveringWholeMonth() {
+        Contract contract = hourlyContract("30.00", LocalDate.of(2024, 1, 1), null);
+        Pto pto = pto(LocalDate.of(2026, 4, 1), LocalDate.of(2026, 4, 30), 30.0, null);
+        var ctx = ctxFor(contract).withPtos(contract.getEmployee().getId(), List.of(pto));
+
+        PayrollItem item = calculator.calculate(contract, ctx.build());
+
+        assertThat(item.getBillableHoursInMonth()).isEqualByComparingTo("0");
+        assertThat(item.getBaseSalary()).isEqualByComparingTo("0.00");
+    }
+
+    // -- Horas extras --------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("MONTHLY contract with overtime → overtime amount = hours * salary / (21.6 * 8)")
+    void monthlyOvertimeUsesDerivedRate() {
+        Contract contract = monthlyContract("4400.00", LocalDate.of(2024, 1, 1), null);
+        Overtime ot = overtime(contract.getEmployee(), 5f, LocalDate.of(2026, 4, 10));
+        var ctx = ctxFor(contract).withOvertimes(contract.getEmployee().getId(), List.of(ot));
+
+        PayrollItem item = calculator.calculate(contract, ctx.build());
+
+        // 4400 / 172.8 = 25.4630 per hour; 5h * 25.4630 = 127.3150 → 127.32
+        assertThat(item.getOvertimeHours()).isEqualByComparingTo("5");
+        assertThat(item.getOvertimeAmount()).isEqualByComparingTo("127.32");
+    }
+
+    @Test
+    @DisplayName("HOUR contract with overtime → overtime amount uses contract hourly rate")
+    void hourlyOvertimeUsesHourlyRate() {
+        Contract contract = hourlyContract("30.00", LocalDate.of(2024, 1, 1), null);
+        Overtime ot = overtime(contract.getEmployee(), 3f, LocalDate.of(2026, 4, 10));
+        var ctx = ctxFor(contract).withOvertimes(contract.getEmployee().getId(), List.of(ot));
+
+        PayrollItem item = calculator.calculate(contract, ctx.build());
+
+        assertThat(item.getOvertimeHours()).isEqualByComparingTo("3");
+        assertThat(item.getOvertimeAmount()).isEqualByComparingTo("90.00");
+    }
+
+    @Test
+    @DisplayName("Overtime hours from float 2.1f → BigDecimal 2.1 exactly, no binary drift")
+    void overtimeHoursFromFloatHasNoBinaryDrift() {
+        // 2.1f cannot be represented exactly in IEEE-754 binary. BigDecimal.valueOf((double) 2.1f)
+        // widens to ~2.0999999046... and propagates the drift into overtimeHours. Routing through
+        // Float.toString(2.1f) = "2.1" yields exactly 2.1. This test pins the fix.
+        Contract contract = monthlyContract("4400.00", LocalDate.of(2024, 1, 1), null);
+        Overtime ot = overtime(contract.getEmployee(), 2.1f, LocalDate.of(2026, 4, 10));
+        var ctx = ctxFor(contract).withOvertimes(contract.getEmployee().getId(), List.of(ot));
+
+        PayrollItem item = calculator.calculate(contract, ctx.build());
+
+        assertThat(item.getOvertimeHours()).isEqualByComparingTo("2.1");
+    }
+
+    @Test
+    @DisplayName("No overtime records → overtime fields are zero")
+    void noOvertime() {
+        Contract contract = monthlyContract("4400.00", LocalDate.of(2024, 1, 1), null);
+        var ctx = ctxFor(contract);
+
+        PayrollItem item = calculator.calculate(contract, ctx.build());
+
+        assertThat(item.getOvertimeHours()).isEqualByComparingTo("0");
+        assertThat(item.getOvertimeAmount()).isEqualByComparingTo("0.00");
+    }
+
+    // -- Reintegros ----------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("Reimbursements → summed into reimbursementsAmount")
+    void reimbursementsSummed() {
+        Contract contract = monthlyContract("4400.00", LocalDate.of(2024, 1, 1), null);
+        Reimbursement r = reimbursement(contract.getEmployee(), "Gym", new BigDecimal("50"));
+        var ctx = ctxFor(contract).withReimbursements(contract.getEmployee().getId(), List.of(r));
+
+        PayrollItem item = calculator.calculate(contract, ctx.build());
+
+        assertThat(item.getReimbursementsAmount()).isEqualByComparingTo("50");
+    }
+
+    // -- Licencia sin goce ---------------------------------------------------------------------
+
+    @Test
+    @DisplayName("MONTHLY full month + 8 business days unpaid leave → deduction = (salary/21.6) * 8, total = salary - deduction")
+    void monthlyWithUnpaidLeaveDeducts() {
+        // Mirrors the prod example: salary 5000, 8 weekdays sin goce → deduction 1851.85, total 3148.15.
+        Contract contract = monthlyContract("5000.00", LocalDate.of(2024, 1, 1), null);
+        // Apr 21 (Tue) - Apr 30 (Thu) = 8 weekdays.
+        Pto leave = unpaidLeave(LocalDate.of(2026, 4, 21), LocalDate.of(2026, 4, 30), 8.0);
+        var ctx = ctxFor(contract).withPtos(contract.getEmployee().getId(), List.of(leave));
+
+        PayrollItem item = calculator.calculate(contract, ctx.build());
+
+        assertThat(item.getBaseSalary()).isEqualByComparingTo("5000.00");
+        assertThat(item.getUnpaidLeaveHoursInMonth()).isEqualByComparingTo("64"); // 8 days * 8h
+        // (5000/172.8) * 64 = 28.9352 * 64 = 1851.8528 → 1851.85
+        assertThat(item.getUnpaidLeaveDeduction()).isEqualByComparingTo("1851.85");
+        assertThat(item.getTotalAmount()).isEqualByComparingTo("3148.15");
+    }
+
+    @Test
+    @DisplayName("Unpaid leave overlapping a holiday → holiday is paid, deduction skips it")
+    void unpaidLeaveExcludesHolidaysFromDeduction() {
+        // Apr 21-30: 8 weekdays. With holiday Apr 22 → only 7 unpaid business days.
+        Contract contract = monthlyContract("5000.00", LocalDate.of(2024, 1, 1), null);
+        Pto leave = unpaidLeave(LocalDate.of(2026, 4, 21), LocalDate.of(2026, 4, 30), 8.0);
+        var ctx = ctxFor(contract)
+                .withPtos(contract.getEmployee().getId(), List.of(leave))
+                .withHoliday(argentinaId, LocalDate.of(2026, 4, 22));
+
+        PayrollItem item = calculator.calculate(contract, ctx.build());
+
+        assertThat(item.getUnpaidLeaveHoursInMonth()).isEqualByComparingTo("56"); // 7 * 8
+        // (5000/172.8) * 56 = 28.9352 * 56 = 1620.3712 → 1620.37
+        assertThat(item.getUnpaidLeaveDeduction()).isEqualByComparingTo("1620.37");
+        assertThat(item.getTotalAmount()).isEqualByComparingTo("3379.63");
+    }
+
+    @Test
+    @DisplayName("Regular paid PTO (no LeaveType.name = Unpaid License) → no salary deduction")
+    void regularPtoDoesNotDeductSalary() {
+        Contract contract = monthlyContract("5000.00", LocalDate.of(2024, 1, 1), null);
+        Pto regular = pto(LocalDate.of(2026, 4, 21), LocalDate.of(2026, 4, 30), 8.0, null); // no leaveType
+        var ctx = ctxFor(contract).withPtos(contract.getEmployee().getId(), List.of(regular));
+
+        PayrollItem item = calculator.calculate(contract, ctx.build());
+
+        assertThat(item.getUnpaidLeaveHoursInMonth()).isEqualByComparingTo("0");
+        assertThat(item.getUnpaidLeaveDeduction()).isEqualByComparingTo("0");
+        assertThat(item.getTotalAmount()).isEqualByComparingTo("5000.00");
+    }
+
+    @Test
+    @DisplayName("HOUR contract with unpaid leave → no explicit deduction (unpaid hours already drop billableHours)")
+    void hourlyWithUnpaidLeaveDoesNotDoubleDeduct() {
+        Contract contract = hourlyContract("30.00", LocalDate.of(2024, 1, 1), null);
+        Pto leave = unpaidLeave(LocalDate.of(2026, 4, 21), LocalDate.of(2026, 4, 30), 8.0);
+        var ctx = ctxFor(contract).withPtos(contract.getEmployee().getId(), List.of(leave));
+
+        PayrollItem item = calculator.calculate(contract, ctx.build());
+
+        assertThat(item.getUnpaidLeaveHoursInMonth()).isEqualByComparingTo("64");
+        assertThat(item.getUnpaidLeaveDeduction()).isEqualByComparingTo("0");
+        // billableHours = 176 - 64 = 112; baseSalary = 30 * 112 = 3360
+        assertThat(item.getBillableHoursInMonth()).isEqualByComparingTo("112");
+        assertThat(item.getBaseSalary()).isEqualByComparingTo("3360.00");
+        assertThat(item.getTotalAmount()).isEqualByComparingTo("3360.00");
+    }
+
+    // -- Liquidación final ---------------------------------------------------------------------
+
+    @Test
+    @DisplayName("Final settlement with unused vacation days → vacationCashout = days * dailyRate")
+    void finalSettlementUnusedVacation() {
+        // contract starts 2 years before period; ends Apr 30. 5 unused days. Daily rate = 4400/21.6 = 203.7037.
+        Contract contract = monthlyContract("4400.00", LocalDate.of(2024, 1, 1), LocalDate.of(2026, 4, 30));
+        Vacation v = vacation(2026, 10, 5);
+        var ctx = ctxFor(contract).withVacations(contract.getEmployee().getId(), List.of(v));
+
+        PayrollItem item = calculator.calculate(contract, ctx.build());
+
+        assertThat(item.isFinalSettlement()).isTrue();
+        // 5 unused * 203.7037/day = 1018.5185 → 1018.52
+        assertThat(item.getVacationCashout()).isEqualByComparingTo("1018.52");
+    }
+
+    @Test
+    @DisplayName("Final settlement with <12 months service → hardware clawback equals last-12-months Hardware reimbursements sum")
+    void finalSettlementHardwareClawbackUnder12Months() {
+        Contract contract = monthlyContract("4400.00", LocalDate.of(2025, 11, 1), LocalDate.of(2026, 4, 30));
+        Reimbursement hw1 = reimbursement(contract.getEmployee(), "Bono de Hardware", new BigDecimal("1500"));
+        Reimbursement hw2 = reimbursement(contract.getEmployee(), "Bono de Hardware", new BigDecimal("500"));
+        var ctx = ctxFor(contract)
+                .withHardwareReimbursementsLast12m(contract.getEmployee().getId(), List.of(hw1, hw2));
+
+        PayrollItem item = calculator.calculate(contract, ctx.build());
+
+        assertThat(item.getHardwareClawback()).isEqualByComparingTo("2000");
+    }
+
+    @Test
+    @DisplayName("Final settlement with ≥12 months service → no hardware clawback")
+    void finalSettlementNoClawbackOver12Months() {
+        Contract contract = monthlyContract("4400.00", LocalDate.of(2024, 1, 1), LocalDate.of(2026, 4, 30));
+        Reimbursement hw = reimbursement(contract.getEmployee(), "Bono de Hardware", new BigDecimal("1500"));
+        var ctx = ctxFor(contract)
+                .withHardwareReimbursementsLast12m(contract.getEmployee().getId(), List.of(hw));
+
+        PayrollItem item = calculator.calculate(contract, ctx.build());
+
+        assertThat(item.getHardwareClawback()).isEqualByComparingTo("0");
+    }
+
+    @Test
+    @DisplayName("Final settlement with no Hardware reimbursements seen → clawback is zero (warning logged)")
+    void finalSettlementHardwareClawbackZeroWhenAbsent() {
+        Contract contract = monthlyContract("4400.00", LocalDate.of(2025, 11, 1), LocalDate.of(2026, 4, 30));
+        var ctx = ctxFor(contract);
+
+        PayrollItem item = calculator.calculate(contract, ctx.build());
+
+        assertThat(item.getHardwareClawback()).isEqualByComparingTo("0");
+    }
+
+    @Test
+    @DisplayName("Final settlement with multi-year vacations → negative-year debt compensates positive-year credit")
+    void finalSettlementUnusedVacationCompensatesAcrossYears() {
+        // Business rule per CTO: include ALL years, sum net across rows, floor only the final net.
+        // 2025: credit 10, debit 4 → +6. 2026: credit 2, debit 5 → -3. Net = +3 unused days.
+        Contract contract = monthlyContract("4400.00", LocalDate.of(2024, 1, 1), LocalDate.of(2026, 4, 30));
+        Vacation prior = vacation(2025, 10, 4);
+        Vacation current = vacation(2026, 2, 5);
+        var ctx = ctxFor(contract).withVacations(contract.getEmployee().getId(), List.of(prior, current));
+
+        PayrollItem item = calculator.calculate(contract, ctx.build());
+
+        // 3 unused days * (4400/21.6) = 3 * 203.7037 = 611.1111 → 611.11
+        assertThat(item.getVacationCashout()).isEqualByComparingTo("611.11");
+    }
+
+    @Test
+    @DisplayName("Final settlement with net-negative vacation balance → vacationCashout is 0, never negative")
+    void finalSettlementUnusedVacationNetNegativeFlooredAtZero() {
+        // 2025: -2 (credit 1 debit 3). 2026: -4 (credit 1 debit 5). Net = -6 → cashout 0, not negative.
+        Contract contract = monthlyContract("4400.00", LocalDate.of(2024, 1, 1), LocalDate.of(2026, 4, 30));
+        Vacation prior = vacation(2025, 1, 3);
+        Vacation current = vacation(2026, 1, 5);
+        var ctx = ctxFor(contract).withVacations(contract.getEmployee().getId(), List.of(prior, current));
+
+        PayrollItem item = calculator.calculate(contract, ctx.build());
+
+        assertThat(item.getVacationCashout()).isEqualByComparingTo("0");
+    }
+
+    @Test
+    @DisplayName("Contract active but not ending → isFinalSettlement false, cashout zero")
+    void contractActiveNotEnding() {
+        Contract contract = monthlyContract("4400.00", LocalDate.of(2024, 1, 1), null);
+        Vacation v = vacation(2026, 10, 5);
+        var ctx = ctxFor(contract).withVacations(contract.getEmployee().getId(), List.of(v));
+
+        PayrollItem item = calculator.calculate(contract, ctx.build());
+
+        assertThat(item.isFinalSettlement()).isFalse();
+        assertThat(item.getVacationCashout()).isEqualByComparingTo("0");
+    }
+
+    // -- Aislamiento de fallos ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("Contract with no PaymentSettlement → calculationError set, totals zero, no exception")
+    void contractWithNoPaymentSettlement() {
+        Employee emp = employee("E099");
+        Contract contract = new Contract();
+        contract.setId(UUID.randomUUID());
+        contract.setEmployee(emp);
+        contract.setStartDate(LocalDate.of(2024, 1, 1));
+        // No payment settlements at all.
+        var ctx = ctxFor(contract);
+
+        PayrollItem item = calculator.calculate(contract, ctx.build());
+
+        assertThat(item.getCalculationError()).contains("payment settlement");
+        assertThat(item.getTotalAmount()).isEqualByComparingTo("0");
+    }
+
+    // -- Total -----------------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("All components positive → totalAmount sums them correctly")
+    void totalAmountSumsAllComponents() {
+        Contract contract = monthlyContract("4400.00", LocalDate.of(2024, 1, 1), null);
+        Overtime ot = overtime(contract.getEmployee(), 4f, LocalDate.of(2026, 4, 10));
+        Reimbursement r = reimbursement(contract.getEmployee(), "Internet", new BigDecimal("50"));
+        var ctx = ctxFor(contract)
+                .withOvertimes(contract.getEmployee().getId(), List.of(ot))
+                .withReimbursements(contract.getEmployee().getId(), List.of(r));
+
+        PayrollItem item = calculator.calculate(contract, ctx.build());
+
+        // base 4400 + ot 4 * (4400/172.8) = 4 * 25.4630 = 101.85 + reimbursements 50 = 4551.85
+        assertThat(item.getTotalAmount()).isEqualByComparingTo("4551.85");
+    }
+
+    @Test
+    @DisplayName("recomputeTotals includes adjustment and previousBalance")
+    void totalsIncludeAdjustmentAndPreviousBalance() {
+        PayrollItem item = new PayrollItem();
+        item.setBaseSalary(new BigDecimal("4400"));
+        item.setAdjustment(new BigDecimal("100"));
+        item.setPreviousBalance(new BigDecimal("-30"));
+
+        calculator.recomputeTotals(item);
+
+        assertThat(item.getTotalAmount()).isEqualByComparingTo("4470.00");
+    }
+
+    // -- Helpers ----------------------------------------------------------------------------------
+
+    private Employee employee(String internalId) {
+        Employee e = new Employee();
+        e.setId(UUID.randomUUID());
+        e.setInternalId(internalId);
+        e.setFirstName("Test");
+        e.setLastName(internalId);
+        e.setActive(true);
+        e.setCountry(argentina);
+        return e;
+    }
+
+    private Contract monthlyContract(String salary, LocalDate start, LocalDate end) {
+        return contract(employee("E" + (System.nanoTime() % 1000)),
+                start, end,
+                paymentSettlement(new BigDecimal(salary), Modality.MONTHLY, Currency.USD));
+    }
+
+    private Contract hourlyContract(String hourlyRate, LocalDate start, LocalDate end) {
+        return contract(employee("E" + (System.nanoTime() % 1000)),
+                start, end,
+                paymentSettlement(new BigDecimal(hourlyRate), Modality.HOUR, Currency.USD));
+    }
+
+    private Contract contract(Employee employee, LocalDate start, LocalDate end, PaymentSettlement... settlements) {
+        Contract c = new Contract();
+        c.setId(UUID.randomUUID());
+        c.setEmployee(employee);
+        c.setStartDate(start);
+        c.setEndDate(end);
+        c.setActive(true);
+        Set<PaymentSettlement> set = new HashSet<>();
+        for (PaymentSettlement ps : settlements) {
+            ps.setContract(c);
+            set.add(ps);
+        }
+        c.setPaymentsSettlement(set);
+        return c;
+    }
+
+    private PaymentSettlement paymentSettlement(BigDecimal salary, Modality modality, Currency currency) {
+        PaymentSettlement ps = new PaymentSettlement();
+        ps.setId(UUID.randomUUID());
+        ps.setSalary(salary);
+        ps.setModality(modality);
+        ps.setCurrency(currency);
+        return ps;
+    }
+
+    private Pto pto(LocalDate start, LocalDate end, double days, Integer labourHours) {
+        Pto p = new Pto();
+        p.setId(UUID.randomUUID());
+        p.setStartDate(start);
+        p.setEndDate(end);
+        p.setDays(days);
+        p.setLabourHours(labourHours);
+        p.setStatus(Status.APPROVED);
+        return p;
+    }
+
+    private Pto unpaidLeave(LocalDate start, LocalDate end, double days) {
+        Pto p = pto(start, end, days, null);
+        LeaveType lt = new LeaveType();
+        lt.setId(UUID.randomUUID());
+        lt.setName(PayrollCalculatorService.UNPAID_LEAVE_TYPE);
+        p.setLeaveType(lt);
+        return p;
+    }
+
+    private Overtime overtime(Employee employee, float hours, LocalDate date) {
+        Overtime o = new Overtime();
+        o.setId(UUID.randomUUID());
+        o.setEmployee(employee);
+        o.setHours(hours);
+        o.setDate(date);
+        return o;
+    }
+
+    private Reimbursement reimbursement(Employee employee, String categoryName, BigDecimal amount) {
+        ReimbursementCategory cat = new ReimbursementCategory();
+        cat.setId(UUID.randomUUID());
+        cat.setName(categoryName);
+        Reimbursement r = new Reimbursement();
+        r.setId(UUID.randomUUID());
+        r.setEmployee(employee);
+        r.setCategory(cat);
+        r.setAmount(amount);
+        r.setDate(LocalDate.of(2026, 4, 5));
+        return r;
+    }
+
+    private Vacation vacation(int year, int credit, int debit) {
+        Vacation v = new Vacation();
+        v.setId(UUID.randomUUID());
+        v.setYear(String.valueOf(year));
+        v.setCredit(credit);
+        v.setDebit(debit);
+        return v;
+    }
+
+    private CtxBuilder ctxFor(Contract contract) {
+        return new CtxBuilder(PERIOD, List.of(contract), argentinaId,
+                APRIL_2026_BUSINESS_HOURS_NO_HOLIDAYS);
+    }
+
+    /**
+     * Builder that wraps the mutable maps the calculator reads from. Records can't be subclassed,
+     * so we accumulate state here and pass through to {@link PayrollCalculatorService} by being
+     * implicitly converted via {@link #build()} — but since the calculator takes a PayrollContext
+     * directly, we just expose all the methods Calculator might call.
+     */
+    private static class CtxBuilder {
+        private final LocalDate period;
+        private final List<Contract> contracts;
+        private final Map<UUID, List<Overtime>> overtimes = new HashMap<>();
+        private final Map<UUID, List<Reimbursement>> reimbursements = new HashMap<>();
+        private final Map<UUID, List<Reimbursement>> hardware = new HashMap<>();
+        private final Map<UUID, List<Vacation>> vacations = new HashMap<>();
+        private final Map<UUID, List<Pto>> ptos = new HashMap<>();
+        private final Map<UUID, Set<LocalDate>> holidayDates = new HashMap<>();
+        private final Map<UUID, Integer> workingHours = new HashMap<>();
+        private final Map<UUID, String> clientNames = new HashMap<>();
+        private final Map<UUID, String> platforms = new HashMap<>();
+        private final Map<UUID, LocalDate> hireDates = new HashMap<>();
+
+        CtxBuilder(LocalDate period, List<Contract> contracts,
+                UUID defaultCountryId, int defaultWorkingHoursInMonth) {
+            this.period = period;
+            this.contracts = contracts;
+            this.holidayDates.put(defaultCountryId, new HashSet<>());
+            this.workingHours.put(defaultCountryId, defaultWorkingHoursInMonth);
+        }
+
+        CtxBuilder withPtos(UUID employeeId, List<Pto> v) { ptos.put(employeeId, v); return this; }
+        CtxBuilder withOvertimes(UUID employeeId, List<Overtime> v) { overtimes.put(employeeId, v); return this; }
+        CtxBuilder withReimbursements(UUID employeeId, List<Reimbursement> v) { reimbursements.put(employeeId, v); return this; }
+        CtxBuilder withHardwareReimbursementsLast12m(UUID employeeId, List<Reimbursement> v) {
+            hardware.put(employeeId, v); return this;
+        }
+        CtxBuilder withVacations(UUID employeeId, List<Vacation> v) { vacations.put(employeeId, v); return this; }
+        CtxBuilder withHireDate(UUID employeeId, LocalDate date) { hireDates.put(employeeId, date); return this; }
+
+        CtxBuilder withHoliday(UUID countryId, LocalDate date) {
+            holidayDates.computeIfAbsent(countryId, k -> new HashSet<>()).add(date);
+            Set<LocalDate> holidays = holidayDates.get(countryId);
+            workingHours.put(countryId,
+                    PayrollDataLoader.computeWorkingHours(period.withDayOfMonth(1),
+                            period.withDayOfMonth(period.lengthOfMonth()), holidays));
+            return this;
+        }
+
+        PayrollContext build() {
+            return new PayrollContext(period, contracts, overtimes, reimbursements,
+                    hardware, vacations, ptos, holidayDates, workingHours, clientNames, platforms, hireDates);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static Set<LocalDate> emptyHolidays() {
+        return Collections.emptySet();
+    }
+}

--- a/src/test/java/com/entropyteam/entropay/employees/payroll/PayrollOrchestratorServiceTest.java
+++ b/src/test/java/com/entropyteam/entropay/employees/payroll/PayrollOrchestratorServiceTest.java
@@ -1,0 +1,147 @@
+package com.entropyteam.entropay.employees.payroll;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import com.entropyteam.entropay.employees.models.Contract;
+import com.entropyteam.entropay.employees.models.Employee;
+
+@ExtendWith(MockitoExtension.class)
+class PayrollOrchestratorServiceTest {
+
+    @Mock private PayrollDataLoader dataLoader;
+    @Mock private PayrollPersister persister;
+
+    @Captor private ArgumentCaptor<List<PayrollItem>> itemsCaptor;
+
+    private PayrollCalculatorService calculator;
+    private PayrollOrchestratorService orchestrator;
+    private final Executor executor = Runnable::run;
+
+    @BeforeEach
+    void setUp() {
+        calculator = new PayrollCalculatorService();
+        orchestrator = new PayrollOrchestratorService(
+                dataLoader, calculator, persister, executor);
+    }
+
+    @Test
+    void givenMultipleEmployees_whenStartPayrollRun_thenAllItemsCalculatedAndBatchPersisted() {
+        UUID runId = UUID.randomUUID();
+        LocalDate period = LocalDate.of(2026, 4, 1);
+        Contract c1 = simpleContract("E001", new BigDecimal("4000"));
+        Contract c2 = simpleContract("E002", new BigDecimal("5000"));
+        when(dataLoader.loadContext(eq(period))).thenReturn(emptyContextWith(period, List.of(c1, c2)));
+
+        CompletableFuture<UUID> result = orchestrator.startPayrollRun(runId, period);
+        assertThat(result).isCompletedWithValue(runId);
+
+        verify(persister).persistRunResult(eq(runId), itemsCaptor.capture(), any(), eq(2));
+        List<PayrollItem> items = itemsCaptor.getValue();
+        assertThat(items).hasSize(2);
+        assertThat(items).allMatch(i -> i.getCalculationError() == null);
+    }
+
+    @Test
+    void givenOneCalculationFails_thenItemMarkedWithErrorAndOthersStillPersisted() {
+        UUID runId = UUID.randomUUID();
+        LocalDate period = LocalDate.of(2026, 4, 1);
+        Contract good = simpleContract("E001", new BigDecimal("4000"));
+        Contract broken = brokenContractMissingSettlement("E002");
+        when(dataLoader.loadContext(eq(period))).thenReturn(emptyContextWith(period, List.of(good, broken)));
+
+        orchestrator.startPayrollRun(runId, period);
+
+        verify(persister).persistRunResult(eq(runId), itemsCaptor.capture(), any(), eq(2));
+        List<PayrollItem> items = itemsCaptor.getValue();
+        assertThat(items).hasSize(2);
+        assertThat(items).filteredOn(i -> i.getCalculationError() != null).hasSize(1);
+        verify(persister, never()).persistRunFailure(any(), any());
+    }
+
+    @Test
+    void givenLoaderThrows_thenRunMarkedFailedWithErrorMessage() {
+        UUID runId = UUID.randomUUID();
+        LocalDate period = LocalDate.of(2026, 4, 1);
+        when(dataLoader.loadContext(eq(period))).thenThrow(new RuntimeException("DB exploded"));
+
+        CompletableFuture<UUID> result = orchestrator.startPayrollRun(runId, period);
+
+        assertThat(result).isCompletedExceptionally();
+        verify(persister).persistRunFailure(eq(runId), org.mockito.ArgumentMatchers.contains("DB exploded"));
+        verify(persister, never()).persistRunResult(any(), any(), any(), anyInt());
+    }
+
+    private Contract simpleContract(String internalId, BigDecimal salary) {
+        Employee e = new Employee();
+        e.setId(UUID.randomUUID());
+        e.setInternalId(internalId);
+        Contract c = new Contract();
+        c.setId(UUID.randomUUID());
+        c.setEmployee(e);
+        c.setStartDate(LocalDate.of(2024, 1, 1));
+        c.setActive(true);
+        var ps = new com.entropyteam.entropay.employees.models.PaymentSettlement();
+        ps.setId(UUID.randomUUID());
+        ps.setSalary(salary);
+        ps.setModality(com.entropyteam.entropay.employees.models.Modality.MONTHLY);
+        ps.setCurrency(com.entropyteam.entropay.employees.models.Currency.USD);
+        ps.setContract(c);
+        c.setPaymentsSettlement(new HashSet<>(List.of(ps)));
+        return c;
+    }
+
+    private Contract brokenContractMissingSettlement(String internalId) {
+        Employee e = new Employee();
+        e.setId(UUID.randomUUID());
+        e.setInternalId(internalId);
+        Contract c = new Contract();
+        c.setId(UUID.randomUUID());
+        c.setEmployee(e);
+        c.setStartDate(LocalDate.of(2024, 1, 1));
+        return c; // No paymentsSettlement → calculator records calculationError, no exception.
+    }
+
+    private PayrollContext emptyContextWith(LocalDate period, List<Contract> contracts) {
+        return new PayrollContext(
+                period,
+                contracts,
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                new HashMap<>(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap()
+        );
+    }
+
+    @SuppressWarnings("unused")
+    private static HashSet<LocalDate> empty() {
+        return new HashSet<>();
+    }
+}

--- a/src/test/java/com/entropyteam/entropay/employees/payroll/PayrollPersisterTest.java
+++ b/src/test/java/com/entropyteam/entropay/employees/payroll/PayrollPersisterTest.java
@@ -1,0 +1,121 @@
+package com.entropyteam.entropay.employees.payroll;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PayrollPersisterTest {
+
+    @Mock private PayrollRunRepository payrollRunRepository;
+    @Mock private PayrollItemRepository payrollItemRepository;
+
+    @InjectMocks private PayrollPersister persister;
+
+    private UUID runId;
+
+    @BeforeEach
+    void setUp() {
+        runId = UUID.randomUUID();
+    }
+
+    @Test
+    void persistRunResult_whenRunIsRunning_thenWritesItemsAndFlipsToDraft() {
+        PayrollRun run = newRun(PayrollRunStatus.RUNNING, false);
+        when(payrollRunRepository.findById(runId)).thenReturn(Optional.of(run));
+        PayrollItem item = new PayrollItem();
+
+        persister.persistRunResult(runId, List.of(item), new BigDecimal("123.45"), 1);
+
+        assertThat(run.getStatus()).isEqualTo(PayrollRunStatus.DRAFT);
+        assertThat(run.getTotalAmount()).isEqualByComparingTo("123.45");
+        assertThat(run.getEmployeeCount()).isEqualTo(1);
+        assertThat(item.getPayrollRun()).isSameAs(run);
+        verify(payrollItemRepository).saveAll(List.of(item));
+        verify(payrollRunRepository).save(run);
+    }
+
+    @Test
+    void persistRunResult_whenRunWasSoftDeletedMidRun_thenSkipsWriteAndDoesNotResurrect() {
+        PayrollRun deleted = newRun(PayrollRunStatus.RUNNING, true);
+        when(payrollRunRepository.findById(runId)).thenReturn(Optional.of(deleted));
+
+        persister.persistRunResult(runId, List.of(new PayrollItem()), new BigDecimal("1"), 1);
+
+        // Without the guard the orchestrator would write items + flip the deleted run to DRAFT,
+        // leaving a zombie row (deleted=true, status=DRAFT, with items). The guard makes the
+        // late persist a no-op so the user-initiated delete is honored.
+        assertThat(deleted.getStatus()).isEqualTo(PayrollRunStatus.RUNNING);
+        assertThat(deleted.isDeleted()).isTrue();
+        verify(payrollItemRepository, never()).saveAll(any());
+        verify(payrollRunRepository, never()).save(any());
+    }
+
+    @Test
+    void persistRunResult_whenStatusNoLongerRunning_thenSkipsWrite() {
+        // Could happen if the startup sweeper marked the run FAILED in between.
+        PayrollRun swept = newRun(PayrollRunStatus.FAILED, false);
+        when(payrollRunRepository.findById(runId)).thenReturn(Optional.of(swept));
+
+        persister.persistRunResult(runId, List.of(new PayrollItem()), new BigDecimal("1"), 1);
+
+        assertThat(swept.getStatus()).isEqualTo(PayrollRunStatus.FAILED);
+        verify(payrollItemRepository, never()).saveAll(any());
+        verify(payrollRunRepository, never()).save(any());
+    }
+
+    @Test
+    void persistRunResult_whenRunNoLongerExists_thenSkipsWrite() {
+        when(payrollRunRepository.findById(runId)).thenReturn(Optional.empty());
+
+        persister.persistRunResult(runId, List.of(new PayrollItem()), new BigDecimal("1"), 1);
+
+        verify(payrollItemRepository, never()).saveAll(any());
+        verify(payrollRunRepository, never()).save(any());
+    }
+
+    @Test
+    void persistRunFailure_whenRunIsRunning_thenMarksFailed() {
+        PayrollRun run = newRun(PayrollRunStatus.RUNNING, false);
+        when(payrollRunRepository.findById(runId)).thenReturn(Optional.of(run));
+
+        persister.persistRunFailure(runId, "boom");
+
+        assertThat(run.getStatus()).isEqualTo(PayrollRunStatus.FAILED);
+        assertThat(run.getErrorMessage()).isEqualTo("boom");
+        verify(payrollRunRepository).save(run);
+    }
+
+    @Test
+    void persistRunFailure_whenRunWasSoftDeletedMidRun_thenSkipsWrite() {
+        PayrollRun deleted = newRun(PayrollRunStatus.RUNNING, true);
+        when(payrollRunRepository.findById(runId)).thenReturn(Optional.of(deleted));
+
+        persister.persistRunFailure(runId, "boom");
+
+        assertThat(deleted.getStatus()).isEqualTo(PayrollRunStatus.RUNNING);
+        assertThat(deleted.getErrorMessage()).isNull();
+        verify(payrollRunRepository, never()).save(any());
+    }
+
+    private PayrollRun newRun(PayrollRunStatus status, boolean deleted) {
+        PayrollRun r = new PayrollRun();
+        r.setId(runId);
+        r.setStatus(status);
+        r.setDeleted(deleted);
+        return r;
+    }
+}

--- a/src/test/java/com/entropyteam/entropay/employees/payroll/PayrollRunServiceTest.java
+++ b/src/test/java/com/entropyteam/entropay/employees/payroll/PayrollRunServiceTest.java
@@ -229,6 +229,35 @@ class PayrollRunServiceTest {
     }
 
     @Test
+    void delete_whenStatusIsRunningAndUserIsManager_thenConflict() {
+        // RUNNING is unconditionally blocked — even ROLE_ADMIN can't bypass it, because the async
+        // orchestrator could still write items/flip status after the delete commits and resurrect
+        // a "deleted" run. See also PayrollPersisterTest for the defense-in-depth guard.
+        authenticateAs("ROLE_MANAGER/HR");
+        PayrollRun running = run(LocalDate.of(2026, 4, 1), PayrollRunStatus.RUNNING);
+        when(payrollRunRepository.findById(running.getId())).thenReturn(Optional.of(running));
+
+        assertThatThrownBy(() -> service.delete(running.getId()))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting(e -> ((ResponseStatusException) e).getStatusCode())
+                .isEqualTo(HttpStatus.CONFLICT);
+        assertThat(running.isDeleted()).isFalse();
+    }
+
+    @Test
+    void delete_whenStatusIsRunningAndUserIsAdmin_thenConflict() {
+        authenticateAs("ROLE_ADMIN");
+        PayrollRun running = run(LocalDate.of(2026, 4, 1), PayrollRunStatus.RUNNING);
+        when(payrollRunRepository.findById(running.getId())).thenReturn(Optional.of(running));
+
+        assertThatThrownBy(() -> service.delete(running.getId()))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting(e -> ((ResponseStatusException) e).getStatusCode())
+                .isEqualTo(HttpStatus.CONFLICT);
+        assertThat(running.isDeleted()).isFalse();
+    }
+
+    @Test
     void delete_whenStatusIsDraft_thenSoftDeletes() {
         PayrollRun draft = run(LocalDate.of(2026, 4, 1), PayrollRunStatus.DRAFT);
         when(payrollRunRepository.findById(draft.getId())).thenReturn(Optional.of(draft));

--- a/src/test/java/com/entropyteam/entropay/employees/payroll/PayrollRunServiceTest.java
+++ b/src/test/java/com/entropyteam/entropay/employees/payroll/PayrollRunServiceTest.java
@@ -1,0 +1,270 @@
+package com.entropyteam.entropay.employees.payroll;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.AfterEach;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.server.ResponseStatusException;
+import com.entropyteam.entropay.common.ReactAdminMapper;
+
+@ExtendWith(MockitoExtension.class)
+class PayrollRunServiceTest {
+
+    @Mock private PayrollRunRepository payrollRunRepository;
+    @Mock private PayrollItemRepository payrollItemRepository;
+    @Mock private PayrollItemService payrollItemService;
+    @Mock private ReactAdminMapper reactAdminMapper;
+
+    private PayrollRunService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PayrollRunService(payrollRunRepository, payrollItemRepository, payrollItemService, reactAdminMapper);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private void authenticateAs(String role) {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken("test-user", null,
+                        List.of(new SimpleGrantedAuthority(role))));
+    }
+
+    @Test
+    void givenApprovedRunExistsForPeriod_whenCreateRun_thenConflict() {
+        LocalDate period = LocalDate.of(2026, 4, 1);
+        PayrollRun existing = run(period, PayrollRunStatus.APPROVED);
+        when(payrollRunRepository.findByPeriodAndDeletedIsFalse(period)).thenReturn(Optional.of(existing));
+
+        assertThatThrownBy(() -> service.createRunForPeriod(new TriggerPayrollDto(period)))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting(e -> ((ResponseStatusException) e).getStatusCode())
+                .isEqualTo(HttpStatus.CONFLICT);
+
+        verify(payrollRunRepository, never()).save(any());
+        verify(payrollRunRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    void givenClosedRunExistsForPeriod_whenCreateRun_thenConflict() {
+        LocalDate period = LocalDate.of(2026, 4, 1);
+        when(payrollRunRepository.findByPeriodAndDeletedIsFalse(period))
+                .thenReturn(Optional.of(run(period, PayrollRunStatus.CLOSED)));
+
+        assertThatThrownBy(() -> service.createRunForPeriod(new TriggerPayrollDto(period)))
+                .isInstanceOf(ResponseStatusException.class);
+    }
+
+    @Test
+    void givenRunningRunExistsForPeriod_whenCreateRun_thenConflict() {
+        LocalDate period = LocalDate.of(2026, 4, 1);
+        when(payrollRunRepository.findByPeriodAndDeletedIsFalse(period))
+                .thenReturn(Optional.of(run(period, PayrollRunStatus.RUNNING)));
+
+        assertThatThrownBy(() -> service.createRunForPeriod(new TriggerPayrollDto(period)))
+                .isInstanceOf(ResponseStatusException.class);
+    }
+
+    @Test
+    void givenDraftRunExistsForPeriod_whenCreateRun_thenSoftDeletesDraftAndItemsAndCreatesNew() {
+        LocalDate period = LocalDate.of(2026, 4, 1);
+        PayrollRun draft = run(period, PayrollRunStatus.DRAFT);
+        when(payrollRunRepository.findByPeriodAndDeletedIsFalse(period)).thenReturn(Optional.of(draft));
+        when(payrollItemRepository.findAllByPayrollRunIdAndDeletedIsFalse(draft.getId()))
+                .thenReturn(Collections.emptyList());
+        when(payrollRunRepository.saveAndFlush(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        PayrollRun created = service.createRunForPeriod(new TriggerPayrollDto(period));
+
+        assertThat(draft.isDeleted()).isTrue();
+        assertThat(created.getStatus()).isEqualTo(PayrollRunStatus.RUNNING);
+        // Both the soft-deleted draft and the new RUNNING run are persisted with saveAndFlush:
+        // the draft so its UPDATE hits the DB before the new INSERT, and the new run so a unique
+        // constraint violation surfaces inside createRunForPeriod (as 409) rather than at commit (500).
+        verify(payrollRunRepository, times(1)).saveAndFlush(draft);
+        verify(payrollRunRepository, times(2)).saveAndFlush(any());
+    }
+
+    @Test
+    void givenFailedRunExistsForPeriod_whenCreateRun_thenSoftDeletesFailedAndCreatesNew() {
+        LocalDate period = LocalDate.of(2026, 4, 1);
+        PayrollRun failed = run(period, PayrollRunStatus.FAILED);
+        when(payrollRunRepository.findByPeriodAndDeletedIsFalse(period)).thenReturn(Optional.of(failed));
+        when(payrollItemRepository.findAllByPayrollRunIdAndDeletedIsFalse(failed.getId()))
+                .thenReturn(Collections.emptyList());
+        when(payrollRunRepository.saveAndFlush(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        PayrollRun created = service.createRunForPeriod(new TriggerPayrollDto(period));
+
+        assertThat(failed.isDeleted()).isTrue();
+        assertThat(created.getStatus()).isEqualTo(PayrollRunStatus.RUNNING);
+        // saveAndFlush is the load-bearing call: it pushes the soft-delete UPDATE to the DB before
+        // the new RUNNING row's INSERT, avoiding the idx_payroll_run_period_unique_active violation
+        // that Hibernate's default insert-before-update flush order would otherwise produce.
+        verify(payrollRunRepository, times(1)).saveAndFlush(failed);
+    }
+
+    @Test
+    void givenNoExistingRun_whenCreateRun_thenNewRunningRunSavedWithStartTimestamp() {
+        LocalDate period = LocalDate.of(2026, 4, 1);
+        when(payrollRunRepository.findByPeriodAndDeletedIsFalse(period)).thenReturn(Optional.empty());
+        ArgumentCaptor<PayrollRun> captor = ArgumentCaptor.forClass(PayrollRun.class);
+        when(payrollRunRepository.saveAndFlush(any())).thenAnswer(inv -> {
+            PayrollRun r = inv.getArgument(0);
+            r.setId(UUID.randomUUID());
+            return r;
+        });
+
+        PayrollRun result = service.createRunForPeriod(new TriggerPayrollDto(period));
+
+        verify(payrollRunRepository).saveAndFlush(captor.capture());
+        PayrollRun saved = captor.getValue();
+        assertThat(saved.getStatus()).isEqualTo(PayrollRunStatus.RUNNING);
+        assertThat(saved.getStartedAt()).isNotNull();
+        assertThat(saved.getPeriod()).isEqualTo(period);
+        assertThat(result.getStatus()).isEqualTo(PayrollRunStatus.RUNNING);
+    }
+
+    @Test
+    void givenConcurrentInsertRaces_whenCreateRun_thenReturnsConflictNot500() {
+        // Both threads pass findByPeriodAndDeletedIsFalse (empty), both try to INSERT, the second
+        // hits idx_payroll_run_period_unique_active → DataIntegrityViolationException. The fix
+        // catches it inside createRunForPeriod (thanks to saveAndFlush) and surfaces a clean 409.
+        LocalDate period = LocalDate.of(2026, 4, 1);
+        when(payrollRunRepository.findByPeriodAndDeletedIsFalse(period)).thenReturn(Optional.empty());
+        when(payrollRunRepository.saveAndFlush(any()))
+                .thenThrow(new DataIntegrityViolationException(
+                        "duplicate key value violates unique constraint \"idx_payroll_run_period_unique_active\""));
+
+        assertThatThrownBy(() -> service.createRunForPeriod(new TriggerPayrollDto(period)))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting(e -> ((ResponseStatusException) e).getStatusCode())
+                .isEqualTo(HttpStatus.CONFLICT);
+    }
+
+    @Test
+    void approve_whenStatusIsDraft_thenTransitionsToApproved() {
+        PayrollRun draft = run(LocalDate.of(2026, 4, 1), PayrollRunStatus.DRAFT);
+        when(payrollRunRepository.findById(draft.getId())).thenReturn(Optional.of(draft));
+        when(payrollRunRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var result = service.approve(draft.getId());
+
+        assertThat(result.status()).isEqualTo(PayrollRunStatus.APPROVED);
+    }
+
+    @Test
+    void approve_whenStatusIsRunning_thenConflict() {
+        PayrollRun running = run(LocalDate.of(2026, 4, 1), PayrollRunStatus.RUNNING);
+        when(payrollRunRepository.findById(running.getId())).thenReturn(Optional.of(running));
+
+        assertThatThrownBy(() -> service.approve(running.getId()))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting(e -> ((ResponseStatusException) e).getStatusCode())
+                .isEqualTo(HttpStatus.CONFLICT);
+    }
+
+    @Test
+    void delete_whenStatusIsApprovedAndUserIsNotAdmin_thenConflict() {
+        authenticateAs("ROLE_MANAGER/HR");
+        PayrollRun approved = run(LocalDate.of(2026, 4, 1), PayrollRunStatus.APPROVED);
+        when(payrollRunRepository.findById(approved.getId())).thenReturn(Optional.of(approved));
+
+        assertThatThrownBy(() -> service.delete(approved.getId()))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting(e -> ((ResponseStatusException) e).getStatusCode())
+                .isEqualTo(HttpStatus.CONFLICT);
+    }
+
+    @Test
+    void delete_whenStatusIsApprovedAndUserIsAdmin_thenSoftDeletes() {
+        authenticateAs("ROLE_ADMIN");
+        PayrollRun approved = run(LocalDate.of(2026, 4, 1), PayrollRunStatus.APPROVED);
+        when(payrollRunRepository.findById(approved.getId())).thenReturn(Optional.of(approved));
+        when(payrollItemRepository.findAllByPayrollRunIdAndDeletedIsFalse(approved.getId()))
+                .thenReturn(Collections.emptyList());
+
+        service.delete(approved.getId());
+
+        assertThat(approved.isDeleted()).isTrue();
+    }
+
+    @Test
+    void delete_whenStatusIsClosedAndUserIsAdmin_thenSoftDeletes() {
+        authenticateAs("ROLE_ADMIN");
+        PayrollRun closed = run(LocalDate.of(2026, 4, 1), PayrollRunStatus.CLOSED);
+        when(payrollRunRepository.findById(closed.getId())).thenReturn(Optional.of(closed));
+        when(payrollItemRepository.findAllByPayrollRunIdAndDeletedIsFalse(closed.getId()))
+                .thenReturn(Collections.emptyList());
+
+        service.delete(closed.getId());
+
+        assertThat(closed.isDeleted()).isTrue();
+    }
+
+    @Test
+    void delete_whenStatusIsDraft_thenSoftDeletes() {
+        PayrollRun draft = run(LocalDate.of(2026, 4, 1), PayrollRunStatus.DRAFT);
+        when(payrollRunRepository.findById(draft.getId())).thenReturn(Optional.of(draft));
+        when(payrollItemRepository.findAllByPayrollRunIdAndDeletedIsFalse(draft.getId()))
+                .thenReturn(Collections.emptyList());
+
+        service.delete(draft.getId());
+
+        assertThat(draft.isDeleted()).isTrue();
+    }
+
+    @Test
+    void findOne_mapsItemsInOneBatchWithoutPerItemLookup() {
+        PayrollRun run = run(LocalDate.of(2026, 4, 1), PayrollRunStatus.DRAFT);
+        PayrollItem item1 = new PayrollItem();
+        item1.setId(UUID.randomUUID());
+        PayrollItem item2 = new PayrollItem();
+        item2.setId(UUID.randomUUID());
+        when(payrollRunRepository.findById(run.getId())).thenReturn(Optional.of(run));
+        when(payrollItemRepository.findAllByPayrollRunIdAndDeletedIsFalse(run.getId()))
+                .thenReturn(List.of(item1, item2));
+
+        Optional<PayrollRunDto> dto = service.findOne(run.getId());
+
+        assertThat(dto).isPresent();
+        assertThat(dto.get().items()).hasSize(2);
+        // Items already loaded by findAll are mapped directly — no per-item findOne round-trip.
+        verify(payrollItemService, never()).findOne(any());
+        verify(payrollItemService, times(2)).toDTO(any());
+    }
+
+    private PayrollRun run(LocalDate period, PayrollRunStatus status) {
+        PayrollRun r = new PayrollRun();
+        r.setId(UUID.randomUUID());
+        r.setPeriod(period);
+        r.setStatus(status);
+        return r;
+    }
+}

--- a/src/test/java/com/entropyteam/entropay/employees/payroll/PayrollStaleRunSweeperTest.java
+++ b/src/test/java/com/entropyteam/entropay/employees/payroll/PayrollStaleRunSweeperTest.java
@@ -1,0 +1,112 @@
+package com.entropyteam.entropay.employees.payroll;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PayrollStaleRunSweeperTest {
+
+    private static final long THRESHOLD_MINUTES = 60;
+
+    @Mock
+    private PayrollRunRepository payrollRunRepository;
+
+    private PayrollStaleRunSweeper sweeper;
+
+    @BeforeEach
+    void setUp() {
+        sweeper = new PayrollStaleRunSweeper(payrollRunRepository, THRESHOLD_MINUTES);
+    }
+
+    @Test
+    void givenStaleRunningRun_whenSweep_thenMarkedFailedWithErrorMessage() {
+        PayrollRun stale = run(PayrollRunStatus.RUNNING,
+                Instant.now().minus(THRESHOLD_MINUTES + 10, ChronoUnit.MINUTES));
+        when(payrollRunRepository.findAllByStatusAndDeletedIsFalse(PayrollRunStatus.RUNNING))
+                .thenReturn(List.of(stale));
+
+        sweeper.sweepStaleRunningRuns();
+
+        assertThat(stale.getStatus()).isEqualTo(PayrollRunStatus.FAILED);
+        assertThat(stale.getCompletedAt()).isNotNull();
+        assertThat(stale.getErrorMessage()).isNotNull().contains("FAILED");
+        verify(payrollRunRepository, times(1)).save(stale);
+    }
+
+    @Test
+    void givenRecentRunningRun_whenSweep_thenLeftUntouched() {
+        // Started 5 minutes ago — another ECS instance may legitimately still be processing it.
+        PayrollRun recent = run(PayrollRunStatus.RUNNING,
+                Instant.now().minus(5, ChronoUnit.MINUTES));
+        when(payrollRunRepository.findAllByStatusAndDeletedIsFalse(PayrollRunStatus.RUNNING))
+                .thenReturn(List.of(recent));
+
+        sweeper.sweepStaleRunningRuns();
+
+        assertThat(recent.getStatus()).isEqualTo(PayrollRunStatus.RUNNING);
+        verify(payrollRunRepository, never()).save(any());
+    }
+
+    @Test
+    void givenRunningRunWithoutStartedAt_whenSweep_thenLeftUntouched() {
+        PayrollRun noStart = run(PayrollRunStatus.RUNNING, null);
+        when(payrollRunRepository.findAllByStatusAndDeletedIsFalse(PayrollRunStatus.RUNNING))
+                .thenReturn(List.of(noStart));
+
+        sweeper.sweepStaleRunningRuns();
+
+        assertThat(noStart.getStatus()).isEqualTo(PayrollRunStatus.RUNNING);
+        verify(payrollRunRepository, never()).save(any());
+    }
+
+    @Test
+    void givenNoRunningRuns_whenSweep_thenNothingSaved() {
+        when(payrollRunRepository.findAllByStatusAndDeletedIsFalse(PayrollRunStatus.RUNNING))
+                .thenReturn(List.of());
+
+        sweeper.sweepStaleRunningRuns();
+
+        verify(payrollRunRepository, never()).save(any());
+    }
+
+    @Test
+    void givenMixOfStaleAndRecentRuns_whenSweep_thenOnlyStaleOnesFailed() {
+        PayrollRun stale = run(PayrollRunStatus.RUNNING,
+                Instant.now().minus(THRESHOLD_MINUTES + 30, ChronoUnit.MINUTES));
+        PayrollRun recent = run(PayrollRunStatus.RUNNING,
+                Instant.now().minus(2, ChronoUnit.MINUTES));
+        when(payrollRunRepository.findAllByStatusAndDeletedIsFalse(PayrollRunStatus.RUNNING))
+                .thenReturn(List.of(stale, recent));
+
+        sweeper.sweepStaleRunningRuns();
+
+        assertThat(stale.getStatus()).isEqualTo(PayrollRunStatus.FAILED);
+        assertThat(recent.getStatus()).isEqualTo(PayrollRunStatus.RUNNING);
+        verify(payrollRunRepository, times(1)).save(stale);
+        verify(payrollRunRepository, never()).save(recent);
+    }
+
+    private PayrollRun run(PayrollRunStatus status, Instant startedAt) {
+        PayrollRun r = new PayrollRun();
+        r.setId(UUID.randomUUID());
+        r.setPeriod(LocalDate.of(2026, 4, 1));
+        r.setStatus(status);
+        r.setStartedAt(startedAt);
+        return r;
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the manual Google Sheets monthly payroll process used by Administración. ADMIN/HR selects a month, triggers a run, and per-employee items are calculated in parallel from data already in DB (Contract, Overtime, Reimbursement, Pto, Vacation, country working hours).

- New `payroll` package — package-private with `PayrollRunController` + `PayrollItemController` as the only entry points, following the `leakcheck` / `timetracking` encapsulation pattern.
- Lifecycle: `RUNNING → DRAFT → APPROVED → CLOSED`, with `unapprove` and an admin-override delete on `APPROVED`/`CLOSED`. `RUNNING` runs cannot be deleted (would race the async persist).
- Pure `PayrollCalculatorService` (no DB); orchestrator fans out per contract via `@Async` + `CompletableFuture.allOf`, batch-persists via `PayrollPersister` to avoid `@Async`+`@Transactional` self-invocation. The persister no-ops if the run was deleted or transitioned out of `RUNNING` while the async job was computing.
- `PayrollStaleRunSweeper` runs **on application startup** (`@EventListener(ApplicationReadyEvent.class)`) and marks runs left in `RUNNING` past a configurable threshold (default 60 min) as `FAILED` — recovers from JVM/container restarts mid-run. Not scheduled within a single JVM lifetime.
- Handles HOUR and MONTHLY modalities, proportional pay for mid-month start/end, PTO-aware billable hours per country, overtime, multi-currency reimbursements, vacation cashout, hardware-bonus clawback for <12 months of service.

## API

`POST /payroll-runs` body:
```json
{ "period": "2026-05-01" }
```
Today every entropista is paid in USD, so `period` is the only input. The DTO is intentionally minimal (`TriggerPayrollDto.java`); add fields here when multi-currency triggers are needed.

## Changes

**New (`employees/payroll/` package)**
- `PayrollRun`, `PayrollItem`, `PayrollRunStatus`
- `PayrollRunRepository`, `PayrollItemRepository`
- `PayrollContext`, `PayrollDataLoader` (single-shot read-only load)
- `PayrollCalculatorService` (pure)
- `PayrollOrchestratorService` (`@Async`, fan-out)
- `PayrollPersister` (`@Transactional` boundary for batch save, guards against deleted/non-RUNNING runs)
- `PayrollRunService`, `PayrollItemService`
- `PayrollRunController`, `PayrollItemController` (every CRUD method explicitly re-`@Secured`'d to keep `ROLE_DEVELOPMENT` out — `BaseController`'s method-level annotations would otherwise widen access to salary data)
- `PayrollAsyncConfig` (`payrollExecutor` thread pool)
- `PayrollStaleRunSweeper` (startup FAILED-marker for stuck runs)
- DTOs: `PayrollRunDto`, `PayrollItemDto`, `TriggerPayrollDto`

**Migration**
- `V87.0__DDL_create_payroll_run_tables.sql` — `payroll_run` + `payroll_item`, unique index `(period) WHERE deleted = FALSE`, appends `payroll-runs` / `payroll-items` permissions + top-level menu entry for `ROLE_ADMIN`, `ROLE_HR_DIRECTOR`, `ROLE_MANAGER/HR`.

**Repository additions**
- `ContractRepository.findAllOverlappingPeriodForPayroll(periodStart, periodEnd)` — joins fetch employee, country, paymentsSettlement; only active contracts OR contracts ending within the period.
- `ContractRepository.findEarliestStartDateByEmployeeIds(...)` — for the <12 months hardware-clawback rule, preloaded into context to avoid touching the lazy `Employee.contracts` collection from worker threads.
- `ReimbursementRepository.findAllBetweenPeriod(startDate, endDate)`.
- `OvertimeRepository.findByDateBetweenAndDeletedIsFalse(...)`.
- `PtoRepository.findByPeriod` — widened `JOIN FETCH` → `LEFT JOIN FETCH` on `leaveType` so PTOs without a leaveType don't disappear from the calculator's input.
- `VacationRepository.findAllByEmployeeIdInAndDeletedIsFalse(employeeIds)` — replaces a previous full-table scan in the loader.
- `PaymentInformationRepository.findAllByEmployeeIdInAndDeletedIsFalse(employeeIds)` — bulk fetch, avoids N+1 over `Employee.paymentsInformation`.
- `AssignmentRepository.findActiveByEmployeeIdInOverlappingPeriod(employeeIds, periodStart, periodEnd)` — joins project + client, avoids N+1 over `Employee.assignments`.

**Config**
- `application.properties`: `payroll.executor.core-pool-size=4`, `max-pool-size=8`, `queue-capacity=100`.

## Tests

- `PayrollCalculatorServiceTest` — proportional pay (full month, mid-start, mid-end, same-month start+end), billable hours with PTO and holidays per country, overtime for both modalities, multi-currency reimbursements, final settlement with vacation cashout and hardware clawback (12-month boundary), adjustment + previous balance, USD conversion.
- `PayrollOrchestratorServiceTest` — multi-employee batch persist, per-employee error isolation (calculator throw → item gets `calculationError`, run still ends DRAFT), loader failure → run marked FAILED.
- `PayrollRunServiceTest` — state transitions, race-safe `createRunForPeriod` (unique-index 409), admin-override delete on APPROVED/CLOSED, delete-on-RUNNING rejected for both MANAGER_HR and ADMIN.
- `PayrollPersisterTest` — happy path plus the three skip conditions (deleted, status ≠ RUNNING, run missing) for both `persistRunResult` and `persistRunFailure`.
- `PayrollStaleRunSweeperTest` — RUNNING runs older than the threshold get marked FAILED.

61 payroll tests, 201 total in the project.

## Test plan

- [x] `./mvnw test` passes (201 tests).
- [ ] On a fresh DB with `db-backup/` seeded, Flyway applies `V87.0` cleanly.
- [ ] `POST /payroll-runs` with `{ "period": "2026-05-01" }` returns `202` with a run id.
- [ ] `GET /payroll-runs/{id}` shows `status` moving from `RUNNING` → `DRAFT`, items populated.
- [ ] `PUT /payroll-items/{id}` with `adjustment` / `previousBalance` / `notes` updates and recomputes totals — as ROLE_ADMIN/HR_DIRECTOR/MANAGER_HR only; ROLE_DEVELOPMENT gets `403`.
- [ ] `PUT /payroll-runs/{id}/approve` → APPROVED. Re-POST same period → `409`.
- [ ] `DELETE /payroll-runs/{id}` on a RUNNING run → `409` even as admin.
- [ ] Spot-check totals against the `Liquidación de Sueldos` Google Sheet for a recent month — diffs should be only manual adjustments and prior-month balances.

— claude-opus-4-7