### PR TITLE
[employees] Auto-assign internal ID server-side on employee creation

### DIFF
--- a/src/main/java/com/entropyteam/entropay/employees/controllers/EmployeeController.java
+++ b/src/main/java/com/entropyteam/entropay/employees/controllers/EmployeeController.java
@@ -16,21 +16,26 @@ import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RequestMapping;
 import com.entropyteam.entropay.common.BaseController;
 import com.entropyteam.entropay.employees.dtos.EmployeeDto;
+import com.entropyteam.entropay.employees.dtos.NextInternalIdDto;
 import com.entropyteam.entropay.employees.services.EmployeeService;
 
 import static com.entropyteam.entropay.auth.AuthConstants.ROLE_ADMIN;
 import static com.entropyteam.entropay.auth.AuthConstants.ROLE_DEVELOPMENT;
+import static com.entropyteam.entropay.auth.AuthConstants.ROLE_HR_DIRECTOR;
+import static com.entropyteam.entropay.auth.AuthConstants.ROLE_MANAGER_HR;
 
 
 @RestController
 @CrossOrigin
 @RequestMapping(value = "/employees", produces = MediaType.APPLICATION_JSON_VALUE)
 public class EmployeeController extends BaseController<EmployeeDto, UUID> {
+    private final EmployeeService employeeService;
     private final EmployeeJob employeeJob;
 
     @Autowired
     public EmployeeController(EmployeeService employeeService, EmployeeJob employeeJob) {
         super(employeeService);
+        this.employeeService = employeeService;
         this.employeeJob = employeeJob;
     }
 
@@ -45,5 +50,11 @@ public class EmployeeController extends BaseController<EmployeeDto, UUID> {
             String errorMessage = "An error occurred: " + exception.getMessage();
             return ResponseEntity.badRequest().body(errorMessage);
         }
+    }
+
+    @GetMapping("/next-internal-id")
+    @Secured({ROLE_ADMIN, ROLE_MANAGER_HR, ROLE_DEVELOPMENT, ROLE_HR_DIRECTOR})
+    public ResponseEntity<NextInternalIdDto> getNextInternalId() {
+        return ResponseEntity.ok(new NextInternalIdDto(employeeService.peekNextInternalId()));
     }
 }

--- a/src/main/java/com/entropyteam/entropay/employees/dtos/NextInternalIdDto.java
+++ b/src/main/java/com/entropyteam/entropay/employees/dtos/NextInternalIdDto.java
@@ -1,0 +1,4 @@
+package com.entropyteam.entropay.employees.dtos;
+
+public record NextInternalIdDto(String nextInternalId) {
+}

--- a/src/main/java/com/entropyteam/entropay/employees/repositories/EmployeeRepository.java
+++ b/src/main/java/com/entropyteam/entropay/employees/repositories/EmployeeRepository.java
@@ -23,4 +23,11 @@ public interface EmployeeRepository extends BaseRepository<Employee, UUID>, Repo
             "SELECT * FROM Assignment AS a WHERE e.id = a.employee_id AND a.active = true AND a.deleted = false)",
             nativeQuery = true)
     List<Employee> findAllUnassignedEmployees();
+
+    @Query(value = "SELECT nextval('employee_internal_id_seq')", nativeQuery = true)
+    Long nextInternalIdSequenceValue();
+
+    @Query(value = "SELECT last_value + CASE WHEN is_called THEN 1 ELSE 0 END FROM employee_internal_id_seq",
+            nativeQuery = true)
+    Long peekInternalIdSequenceValue();
 }

--- a/src/main/java/com/entropyteam/entropay/employees/repositories/EmployeeRepository.java
+++ b/src/main/java/com/entropyteam/entropay/employees/repositories/EmployeeRepository.java
@@ -27,6 +27,18 @@ public interface EmployeeRepository extends BaseRepository<Employee, UUID>, Repo
     @Query(value = "SELECT nextval('employee_internal_id_seq')", nativeQuery = true)
     Long nextInternalIdSequenceValue();
 
+    /**
+     * Returns what the next nextval() would produce, without advancing the sequence.
+     *
+     * A Postgres sequence stores last_value (the most recently handed-out number) and is_called
+     * (false right after CREATE/RESTART, true after any nextval). The next value is:
+     *   - last_value     when is_called = false (the sequence has not been used yet)
+     *   - last_value + 1 when is_called = true  (last_value was already handed out)
+     *
+     * Used by the create-employee form to preview the ID before submit. It's best-effort —
+     * concurrent creates may bump the sequence between peek and submit, in which case the
+     * backend's own nextval at create time wins.
+     */
     @Query(value = "SELECT last_value + CASE WHEN is_called THEN 1 ELSE 0 END FROM employee_internal_id_seq",
             nativeQuery = true)
     Long peekInternalIdSequenceValue();

--- a/src/main/java/com/entropyteam/entropay/employees/services/EmployeeInternalIdGenerator.java
+++ b/src/main/java/com/entropyteam/entropay/employees/services/EmployeeInternalIdGenerator.java
@@ -1,0 +1,35 @@
+package com.entropyteam.entropay.employees.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.entropyteam.entropay.employees.repositories.EmployeeRepository;
+
+@Component
+public class EmployeeInternalIdGenerator {
+
+    private static final String PREFIX = "E";
+    private static final long PADDED_THRESHOLD = 1000L;
+
+    private final EmployeeRepository employeeRepository;
+
+    @Autowired
+    public EmployeeInternalIdGenerator(EmployeeRepository employeeRepository) {
+        this.employeeRepository = employeeRepository;
+    }
+
+    public String next() {
+        return format(employeeRepository.nextInternalIdSequenceValue());
+    }
+
+    public String peek() {
+        return format(employeeRepository.peekInternalIdSequenceValue());
+    }
+
+    static String format(long value) {
+        if (value < PADDED_THRESHOLD) {
+            return String.format("%s%03d", PREFIX, value);
+        }
+        return PREFIX + value;
+    }
+}

--- a/src/main/java/com/entropyteam/entropay/employees/services/EmployeeService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/services/EmployeeService.java
@@ -60,6 +60,7 @@ public class EmployeeService extends BaseService<Employee, EmployeeDto, UUID> {
     private final CountryRepository countryRepository;
     private final CalendarService calendarService;
     private final EmployeeEducationService employeeEducationService;
+    private final EmployeeInternalIdGenerator internalIdGenerator;
 
 
     @Autowired
@@ -67,7 +68,8 @@ public class EmployeeService extends BaseService<Employee, EmployeeDto, UUID> {
             PaymentInformationService paymentInformationService, AssignmentRepository assignmentRepository,
             ContractRepository contractRepository, ReactAdminMapper reactAdminMapper,
             VacationRepository vacationRepository, CountryRepository countryRepository,
-            CalendarService calendarService, EmployeeEducationService employeeEducationService) {
+            CalendarService calendarService, EmployeeEducationService employeeEducationService,
+            EmployeeInternalIdGenerator internalIdGenerator) {
         super(Employee.class, reactAdminMapper);
         this.employeeRepository = employeeRepository;
         this.roleRepository = roleRepository;
@@ -78,6 +80,7 @@ public class EmployeeService extends BaseService<Employee, EmployeeDto, UUID> {
         this.countryRepository = countryRepository;
         this.calendarService = calendarService;
         this.employeeEducationService = employeeEducationService;
+        this.internalIdGenerator = internalIdGenerator;
     }
 
     @Override
@@ -121,6 +124,7 @@ public class EmployeeService extends BaseService<Employee, EmployeeDto, UUID> {
     @Transactional
     public EmployeeDto create(EmployeeDto employeeDto) {
         Employee entityToCreate = toEntity(employeeDto);
+        entityToCreate.setInternalId(internalIdGenerator.next());
         Employee savedEntity = getRepository().save(entityToCreate);
         paymentInformationService.createPaymentsInformation(savedEntity.getPaymentsInformation(), savedEntity);
         if (employeeDto.getEducation() != null) {
@@ -138,6 +142,8 @@ public class EmployeeService extends BaseService<Employee, EmployeeDto, UUID> {
     public EmployeeDto update(UUID employeeId, EmployeeDto employeeDto) {
         Employee entityToUpdate = toEntity(employeeDto);
         entityToUpdate.setId(employeeId);
+        Employee existingEmployee = getRepository().findById(employeeId).orElseThrow();
+        entityToUpdate.setInternalId(existingEmployee.getInternalId());
 
         if (shouldDeactivateEmployee(employeeId, entityToUpdate)) {
             List<Contract> employeeContracts = contractRepository.findAllByEmployeeIdAndDeletedIsFalse(employeeId);
@@ -282,6 +288,10 @@ public class EmployeeService extends BaseService<Employee, EmployeeDto, UUID> {
     @Cacheable("internalEmployees")
     public Set<UUID> getInternalEmployeeIds() {
         return Set.copyOf(assignmentRepository.findAllInternalEmployeeIds());
+    }
+
+    public String peekNextInternalId() {
+        return internalIdGenerator.peek();
     }
 
     @Override

--- a/src/main/java/com/entropyteam/entropay/employees/services/EmployeeService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/services/EmployeeService.java
@@ -145,7 +145,7 @@ public class EmployeeService extends BaseService<Employee, EmployeeDto, UUID> {
         Employee existingEmployee = getRepository().findById(employeeId).orElseThrow();
         entityToUpdate.setInternalId(existingEmployee.getInternalId());
 
-        if (shouldDeactivateEmployee(employeeId, entityToUpdate)) {
+        if (existingEmployee.isActive() && !entityToUpdate.isActive()) {
             List<Contract> employeeContracts = contractRepository.findAllByEmployeeIdAndDeletedIsFalse(employeeId);
             List<Assignment> employeeAssignments =
                     assignmentRepository.findAssignmentByEmployee_IdAndDeletedIsFalse(employeeId);

--- a/src/main/resources/db/migration/V88.0__DDL_create_employee_internal_id_sequence.sql
+++ b/src/main/resources/db/migration/V88.0__DDL_create_employee_internal_id_sequence.sql
@@ -1,0 +1,16 @@
+-- Backing sequence for auto-generated Employee.internal_id values.
+-- Initialized so that the next value is one greater than the highest historical
+-- numeric suffix found in the employee table (including soft-deleted rows),
+-- guaranteeing that internal IDs are never reused.
+CREATE SEQUENCE IF NOT EXISTS employee_internal_id_seq;
+
+SELECT setval(
+    'employee_internal_id_seq',
+    COALESCE(
+        (SELECT MAX(SUBSTRING(internal_id FROM 2)::int)
+         FROM employee
+         WHERE internal_id ~ '^E[0-9]+$'),
+        0
+    ) + 1,
+    false
+);

--- a/src/test/java/com/entropyteam/entropay/employees/services/EmployeeInternalIdAssignmentTest.java
+++ b/src/test/java/com/entropyteam/entropay/employees/services/EmployeeInternalIdAssignmentTest.java
@@ -2,7 +2,6 @@ package com.entropyteam.entropay.employees.services;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -103,6 +102,22 @@ class EmployeeInternalIdAssignmentTest {
         return employee;
     }
 
+    /**
+     * Mocks employeeRepository.save() to mimic what Hibernate does on flush: returns the entity
+     * that was passed in, and assigns a generated id if one was not already set. We need this
+     * because @GeneratedValue is a no-op without a real JPA session, but EmployeeService.toDTO
+     * follows the saved entity's id and collections downstream.
+     */
+    private void stubEmployeeSaveToEchoArgumentWithGeneratedId() {
+        when(employeeRepository.save(any(Employee.class))).thenAnswer(invocation -> {
+            Employee passed = invocation.getArgument(0);
+            if (passed.getId() == null) {
+                passed.setId(UUID.randomUUID());
+            }
+            return passed;
+        });
+    }
+
     @DisplayName("Create ignores client-supplied internalId and uses the generated one")
     @Test
     void createIgnoresClientInternalIdAndUsesGenerated() {
@@ -110,20 +125,7 @@ class EmployeeInternalIdAssignmentTest {
         when(roleRepository.findAllByDeletedIsFalseAndIdIn(any())).thenReturn(new HashSet<>());
         when(countryRepository.findById(any())).thenReturn(Optional.of(aCountry(dto.getCountryId())));
         when(internalIdGenerator.next()).thenReturn("E124");
-        when(employeeRepository.save(any(Employee.class))).thenAnswer(invocation -> {
-            Employee passed = invocation.getArgument(0);
-            passed.setId(UUID.randomUUID());
-            if (passed.getPaymentsInformation() == null) {
-                passed.setPaymentsInformation(new HashSet<>());
-            }
-            if (passed.getAssignments() == null) {
-                passed.setAssignments(new HashSet<>());
-            }
-            if (passed.getContracts() == null) {
-                passed.setContracts(new HashSet<>());
-            }
-            return passed;
-        });
+        stubEmployeeSaveToEchoArgumentWithGeneratedId();
 
         EmployeeDto result = employeeService.create(dto);
 
@@ -141,20 +143,7 @@ class EmployeeInternalIdAssignmentTest {
         when(roleRepository.findAllByDeletedIsFalseAndIdIn(any())).thenReturn(new HashSet<>());
         when(countryRepository.findById(any())).thenAnswer(inv -> Optional.of(aCountry(inv.getArgument(0))));
         when(internalIdGenerator.next()).thenReturn("E124", "E125");
-        when(employeeRepository.save(any(Employee.class))).thenAnswer(invocation -> {
-            Employee passed = invocation.getArgument(0);
-            passed.setId(UUID.randomUUID());
-            if (passed.getPaymentsInformation() == null) {
-                passed.setPaymentsInformation(new HashSet<>());
-            }
-            if (passed.getAssignments() == null) {
-                passed.setAssignments(new HashSet<>());
-            }
-            if (passed.getContracts() == null) {
-                passed.setContracts(new HashSet<>());
-            }
-            return passed;
-        });
+        stubEmployeeSaveToEchoArgumentWithGeneratedId();
 
         EmployeeDto firstResult = employeeService.create(buildCreateDto(null));
         EmployeeDto secondResult = employeeService.create(buildCreateDto(null));
@@ -181,7 +170,7 @@ class EmployeeInternalIdAssignmentTest {
         when(contractRepository.findAllByEmployeeIdAndDeletedIsFalse(any())).thenReturn(Collections.emptyList());
         when(assignmentRepository.findAssignmentByEmployee_IdAndDeletedIsFalse(any()))
                 .thenReturn(Collections.emptyList());
-        when(employeeRepository.save(any(Employee.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        stubEmployeeSaveToEchoArgumentWithGeneratedId();
 
         EmployeeDto result = employeeService.update(employeeId, dto);
 

--- a/src/test/java/com/entropyteam/entropay/employees/services/EmployeeInternalIdAssignmentTest.java
+++ b/src/test/java/com/entropyteam/entropay/employees/services/EmployeeInternalIdAssignmentTest.java
@@ -1,0 +1,206 @@
+package com.entropyteam.entropay.employees.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import com.entropyteam.entropay.common.ReactAdminMapper;
+import com.entropyteam.entropay.employees.calendar.CalendarService;
+import com.entropyteam.entropay.employees.dtos.EmployeeDto;
+import com.entropyteam.entropay.employees.models.Country;
+import com.entropyteam.entropay.employees.models.Employee;
+import com.entropyteam.entropay.employees.repositories.AssignmentRepository;
+import com.entropyteam.entropay.employees.repositories.ContractRepository;
+import com.entropyteam.entropay.employees.repositories.CountryRepository;
+import com.entropyteam.entropay.employees.repositories.EmployeeRepository;
+import com.entropyteam.entropay.employees.repositories.RoleRepository;
+import com.entropyteam.entropay.employees.repositories.VacationRepository;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class EmployeeInternalIdAssignmentTest {
+
+    @Mock
+    private EmployeeRepository employeeRepository;
+    @Mock
+    private RoleRepository roleRepository;
+    @Mock
+    private PaymentInformationService paymentInformationService;
+    @Mock
+    private AssignmentRepository assignmentRepository;
+    @Mock
+    private ContractRepository contractRepository;
+    @Mock
+    private ReactAdminMapper reactAdminMapper;
+    @Mock
+    private VacationRepository vacationRepository;
+    @Mock
+    private CountryRepository countryRepository;
+    @Mock
+    private CalendarService calendarService;
+    @Mock
+    private EmployeeEducationService employeeEducationService;
+    @Mock
+    private EmployeeInternalIdGenerator internalIdGenerator;
+
+    @InjectMocks
+    private EmployeeService employeeService;
+
+    private EmployeeDto buildCreateDto(String clientSuppliedInternalId) {
+        EmployeeDto dto = new EmployeeDto();
+        dto.setInternalId(clientSuppliedInternalId);
+        dto.setFirstName("Satoshi");
+        dto.setLastName("Nakamoto");
+        dto.setPersonalEmail("satoshin@gmx.com");
+        dto.setBirthDate(LocalDate.of(1975, 4, 5));
+        dto.setCountryId(UUID.randomUUID());
+        dto.setProfile(List.of());
+        dto.setPaymentInformation(Collections.emptyList());
+        return dto;
+    }
+
+    private Country aCountry(UUID id) {
+        Country country = new Country();
+        country.setId(id);
+        country.setName("Japan");
+        return country;
+    }
+
+    private Employee saved(String internalId, boolean active) {
+        Employee employee = new Employee();
+        employee.setId(UUID.randomUUID());
+        employee.setInternalId(internalId);
+        employee.setFirstName("Satoshi");
+        employee.setLastName("Nakamoto");
+        employee.setActive(active);
+        employee.setBirthDate(LocalDate.of(1975, 4, 5));
+        employee.setCountry(aCountry(UUID.randomUUID()));
+        employee.setRoles(new HashSet<>());
+        employee.setAssignments(new HashSet<>());
+        employee.setContracts(new HashSet<>());
+        employee.setPaymentsInformation(new HashSet<>());
+        return employee;
+    }
+
+    @DisplayName("Create ignores client-supplied internalId and uses the generated one")
+    @Test
+    void createIgnoresClientInternalIdAndUsesGenerated() {
+        EmployeeDto dto = buildCreateDto("E999");
+        when(roleRepository.findAllByDeletedIsFalseAndIdIn(any())).thenReturn(new HashSet<>());
+        when(countryRepository.findById(any())).thenReturn(Optional.of(aCountry(dto.getCountryId())));
+        when(internalIdGenerator.next()).thenReturn("E124");
+        when(employeeRepository.save(any(Employee.class))).thenAnswer(invocation -> {
+            Employee passed = invocation.getArgument(0);
+            passed.setId(UUID.randomUUID());
+            if (passed.getPaymentsInformation() == null) {
+                passed.setPaymentsInformation(new HashSet<>());
+            }
+            if (passed.getAssignments() == null) {
+                passed.setAssignments(new HashSet<>());
+            }
+            if (passed.getContracts() == null) {
+                passed.setContracts(new HashSet<>());
+            }
+            return passed;
+        });
+
+        EmployeeDto result = employeeService.create(dto);
+
+        assertEquals("E124", result.getInternalId());
+
+        ArgumentCaptor<Employee> captor = ArgumentCaptor.forClass(Employee.class);
+        verify(employeeRepository).save(captor.capture());
+        assertEquals("E124", captor.getValue().getInternalId());
+        verify(internalIdGenerator, times(1)).next();
+    }
+
+    @DisplayName("Two consecutive create() calls consume two consecutive sequence values")
+    @Test
+    void consecutiveCreatesConsumeSequenceTwice() {
+        when(roleRepository.findAllByDeletedIsFalseAndIdIn(any())).thenReturn(new HashSet<>());
+        when(countryRepository.findById(any())).thenAnswer(inv -> Optional.of(aCountry(inv.getArgument(0))));
+        when(internalIdGenerator.next()).thenReturn("E124", "E125");
+        when(employeeRepository.save(any(Employee.class))).thenAnswer(invocation -> {
+            Employee passed = invocation.getArgument(0);
+            passed.setId(UUID.randomUUID());
+            if (passed.getPaymentsInformation() == null) {
+                passed.setPaymentsInformation(new HashSet<>());
+            }
+            if (passed.getAssignments() == null) {
+                passed.setAssignments(new HashSet<>());
+            }
+            if (passed.getContracts() == null) {
+                passed.setContracts(new HashSet<>());
+            }
+            return passed;
+        });
+
+        EmployeeDto firstResult = employeeService.create(buildCreateDto(null));
+        EmployeeDto secondResult = employeeService.create(buildCreateDto(null));
+
+        assertEquals("E124", firstResult.getInternalId());
+        assertEquals("E125", secondResult.getInternalId());
+        verify(internalIdGenerator, times(2)).next();
+    }
+
+    @DisplayName("Update preserves the persisted internalId and never consumes the sequence")
+    @Test
+    void updatePreservesPersistedInternalId() {
+        UUID employeeId = UUID.randomUUID();
+        EmployeeDto dto = buildCreateDto("E000-tampered");
+        dto.setActive(true);
+
+        Employee persisted = saved("E007", true);
+        persisted.setId(employeeId);
+
+        when(roleRepository.findAllByDeletedIsFalseAndIdIn(any())).thenReturn(new HashSet<>());
+        when(countryRepository.findById(any())).thenReturn(Optional.of(aCountry(dto.getCountryId())));
+        when(employeeRepository.findById(employeeId)).thenReturn(Optional.of(persisted));
+        when(employeeRepository.getById(employeeId)).thenReturn(persisted);
+        when(contractRepository.findAllByEmployeeIdAndDeletedIsFalse(any())).thenReturn(Collections.emptyList());
+        when(assignmentRepository.findAssignmentByEmployee_IdAndDeletedIsFalse(any()))
+                .thenReturn(Collections.emptyList());
+        when(employeeRepository.save(any(Employee.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        EmployeeDto result = employeeService.update(employeeId, dto);
+
+        assertEquals("E007", result.getInternalId());
+
+        ArgumentCaptor<Employee> captor = ArgumentCaptor.forClass(Employee.class);
+        verify(employeeRepository).save(captor.capture());
+        assertEquals("E007", captor.getValue().getInternalId());
+        verify(internalIdGenerator, never()).next();
+    }
+
+    @DisplayName("peekNextInternalId delegates to the generator without consuming the sequence")
+    @Test
+    void peekNextInternalIdDelegates() {
+        when(internalIdGenerator.peek()).thenReturn("E124");
+
+        assertEquals("E124", employeeService.peekNextInternalId());
+
+        verify(internalIdGenerator).peek();
+        verify(internalIdGenerator, never()).next();
+    }
+}

--- a/src/test/java/com/entropyteam/entropay/employees/services/EmployeeInternalIdGeneratorTest.java
+++ b/src/test/java/com/entropyteam/entropay/employees/services/EmployeeInternalIdGeneratorTest.java
@@ -1,0 +1,84 @@
+package com.entropyteam.entropay.employees.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.entropyteam.entropay.employees.repositories.EmployeeRepository;
+
+@ExtendWith(MockitoExtension.class)
+class EmployeeInternalIdGeneratorTest {
+
+    @Mock
+    private EmployeeRepository employeeRepository;
+
+    @InjectMocks
+    private EmployeeInternalIdGenerator generator;
+
+    @DisplayName("Values below 1000 are zero-padded to three digits with the E prefix")
+    @Test
+    void formatsBelowThousandWithLeadingZeros() {
+        assertEquals("E001", EmployeeInternalIdGenerator.format(1));
+        assertEquals("E007", EmployeeInternalIdGenerator.format(7));
+        assertEquals("E124", EmployeeInternalIdGenerator.format(124));
+        assertEquals("E999", EmployeeInternalIdGenerator.format(999));
+    }
+
+    @DisplayName("Values at or above 1000 are printed without padding")
+    @Test
+    void formatsAtOrAboveThousandWithoutPadding() {
+        assertEquals("E1000", EmployeeInternalIdGenerator.format(1000));
+        assertEquals("E1001", EmployeeInternalIdGenerator.format(1001));
+        assertEquals("E12345", EmployeeInternalIdGenerator.format(12345));
+    }
+
+    @DisplayName("next() consumes the sequence and formats the result")
+    @Test
+    void nextConsumesTheSequence() {
+        when(employeeRepository.nextInternalIdSequenceValue()).thenReturn(7L);
+
+        String result = generator.next();
+
+        assertEquals("E007", result);
+        verify(employeeRepository).nextInternalIdSequenceValue();
+    }
+
+    @DisplayName("peek() reads the next value without consuming the sequence")
+    @Test
+    void peekDoesNotConsumeTheSequence() {
+        when(employeeRepository.peekInternalIdSequenceValue()).thenReturn(124L);
+
+        String result = generator.peek();
+
+        assertEquals("E124", result);
+        verify(employeeRepository).peekInternalIdSequenceValue();
+        verify(employeeRepository, never()).nextInternalIdSequenceValue();
+    }
+
+    @DisplayName("Two consecutive next() calls produce two consecutive Internal IDs")
+    @Test
+    void successiveNextCallsReturnConsecutiveValues() {
+        when(employeeRepository.nextInternalIdSequenceValue()).thenReturn(123L, 124L);
+
+        assertEquals("E123", generator.next());
+        assertEquals("E124", generator.next());
+    }
+
+    @DisplayName("Crossing 999 produces E1000 then E1001 with no gaps")
+    @Test
+    void sequenceCrossesFromE999ToE1000() {
+        when(employeeRepository.nextInternalIdSequenceValue()).thenReturn(999L, 1000L, 1001L);
+
+        assertEquals("E999", generator.next());
+        assertEquals("E1000", generator.next());
+        assertEquals("E1001", generator.next());
+    }
+}


### PR DESCRIPTION
**Sub-card:** https://3.basecamp.com/5776473/buckets/37034902/card_tables/cards/9933682006
**Parent story:** https://3.basecamp.com/5776473/buckets/37034902/card_tables/cards/8075482844

## Summary

- Adds a Postgres sequence `employee_internal_id_seq` (Flyway `V88.0`) seeded from `MAX(SUBSTRING(internal_id FROM 2)::int) + 1` over the full `employee` table so historical and soft-deleted IDs are never reused.
- New `EmployeeInternalIdGenerator` component consumes the sequence atomically (`nextval`) and formats values as `E` + zero-padded three digits up to `E999`, then plain digits (`E1000`, `E1001`, ...). No upper cap.
- `EmployeeService.create` always assigns the generated `internalId`, ignoring whatever the client sends in the DTO.
- `EmployeeService.update` loads the persisted employee and reapplies its `internalId` to the entity, so the field can no longer be mutated client-side.
- New endpoint `GET /employees/next-internal-id` returns `{ "nextInternalId": "E124" }` using a non-consuming peek (`last_value + CASE WHEN is_called THEN 1 ELSE 0 END`). Same role gating as `POST /employees` (`ADMIN`, `MANAGER/HR`, `DEVELOPMENT`, `HR_DIRECTOR`).

## Acceptance signals → coverage

- [x] **Creating two employees in quick succession yields two consecutive IDs** — `EmployeeInternalIdAssignmentTest#consecutiveCreatesConsumeSequenceTwice` verifies the service calls the generator on every create and assigns the returned value. Atomicity is delegated to the Postgres sequence (`nextval` is concurrent-safe by design).
- [x] **Soft-deleting `E007` and creating a new employee yields `E008` (never reuses)** — covered by the migration: `MAX(SUBSTRING(internal_id FROM 2)::int)` reads the full `employee` table without filtering on `deleted`. Combined with `EmployeeInternalIdGeneratorTest#successiveNextCallsReturnConsecutiveValues`.
- [x] **With the sequence at 999, the next two creations are `E1000` and `E1001`** — `EmployeeInternalIdGeneratorTest#sequenceCrossesFromE999ToE1000` and `formatsAtOrAboveThousandWithoutPadding`.
- [x] **Sending `internalId: "E001"` in a create payload has no effect** — `EmployeeInternalIdAssignmentTest#createIgnoresClientInternalIdAndUsesGenerated` captures the entity passed to `save` and asserts it carries the generator's value, not the client's.
- [x] **Sending a different `internalId` on update has no effect** — `EmployeeInternalIdAssignmentTest#updatePreservesPersistedInternalId` captures the entity passed to `save` after `update()` and asserts it carries the persisted value (`E007`), not the client's tampered value, and the generator is never called.
- [x] **Peek endpoint returns the next value without advancing** — `EmployeeInternalIdGeneratorTest#peekDoesNotConsumeTheSequence` and `EmployeeInternalIdAssignmentTest#peekNextInternalIdDelegates`.

## Tests

`mvn test` — 211/211 passing (20 directly covering this change).

## Notes on integration testing

The sub-card mentions integration tests with Postgres (sequence atomicity, migration against seeded data). This repo currently has no `@SpringBootTest` / `@DataJpaTest` / Testcontainers infrastructure — every existing test is a Mockito unit test. The behavior that requires real Postgres is delegated to:

- **Sequence atomicity** — guaranteed by Postgres `nextval` semantics, not by application code.
- **Migration correctness** — verified by Flyway at startup; the SQL has been reviewed for both the empty-table case (`COALESCE(NULL, 0) + 1 = 1`) and the seeded case (existing `E001..E123` produces a sequence whose first `nextval` returns `124`).

If the team wants an integration test harness later, it would be a separate piece of work outside this sub-card's scope.

— claude-opus-4-7