### PR TITLE
[employees] Fix: grant employee_internal_id_seq privileges to app role

### DIFF
--- a/src/main/resources/db/migration/V89.0__DDL_grant_employee_internal_id_sequence_privileges.sql
+++ b/src/main/resources/db/migration/V89.0__DDL_grant_employee_internal_id_sequence_privileges.sql
@@ -1,0 +1,32 @@
+-- Grant USAGE, SELECT, and UPDATE on employee_internal_id_seq to every role that
+-- already has SELECT/INSERT/UPDATE privileges on the employee table.
+--
+-- Why: in environments where Flyway runs as a privileged role and the application
+-- connects as a separate, less-privileged role (the standard RDS setup on dev/prod),
+-- new objects created by Flyway are owned by the Flyway role and the app role gets
+-- no implicit privileges. Tables in this codebase happen to have working grants from
+-- baseline setup, but sequences are a separate object class and were not covered,
+-- which broke `GET /employees/next-internal-id` and any future `nextval` call from
+-- the app on dev.
+--
+-- Mirroring the employee table's grantees onto the sequence keeps the fix
+-- environment-agnostic (no hard-coded role names) and idempotent — re-running the
+-- block is safe because GRANT is additive.
+DO $$
+DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN
+        SELECT DISTINCT grantee
+        FROM information_schema.table_privileges
+        WHERE table_schema = current_schema()
+          AND table_name = 'employee'
+          AND privilege_type IN ('SELECT', 'INSERT', 'UPDATE')
+          AND grantee <> 'PUBLIC'
+    LOOP
+        EXECUTE format(
+            'GRANT USAGE, SELECT, UPDATE ON SEQUENCE employee_internal_id_seq TO %I',
+            r.grantee
+        );
+    END LOOP;
+END $$;


### PR DESCRIPTION
**Sub-card:** https://3.basecamp.com/5776473/buckets/37034902/card_tables/cards/9933682006
**Parent story:** https://3.basecamp.com/5776473/buckets/37034902/card_tables/cards/8075482844

## Problem

On dev, calling \`GET /employees/next-internal-id\` returns:

\`\`\`json
{
  \"message\": \"JDBC exception executing SQL [SELECT last_value + CASE WHEN is_called THEN 1 ELSE 0 END FROM employee_internal_id_seq] [ERROR: permission denied for sequence employee_internal_id_seq]\"
}
\`\`\`

Dev (and likely prod) is an RDS setup where Flyway runs as a privileged role separate from the application's connection role. V88 created the sequence but the app role was never granted USAGE on it. Tables in the baseline schema had grants from earlier setup; sequences are a separate Postgres object class that wasn't covered.

## Fix

V89 mirrors the \`employee\` table's grantees onto \`employee_internal_id_seq\`:

\`\`\`sql
DO \$\$
DECLARE
    r RECORD;
BEGIN
    FOR r IN
        SELECT DISTINCT grantee
        FROM information_schema.table_privileges
        WHERE table_schema = current_schema()
          AND table_name = 'employee'
          AND privilege_type IN ('SELECT', 'INSERT', 'UPDATE')
          AND grantee <> 'PUBLIC'
    LOOP
        EXECUTE format(
            'GRANT USAGE, SELECT, UPDATE ON SEQUENCE employee_internal_id_seq TO %I',
            r.grantee
        );
    END LOOP;
END \$\$;
\`\`\`

- **Environment-agnostic**: no hard-coded role names. Whichever role owns \`employee\` table grants on dev/prod gets the matching sequence grants.
- **Idempotent**: \`GRANT\` is additive; re-running the block is safe.
- **Migration-only**: no code changes, no test changes.

## Verification

- \`mvn test\` — 211/211 passing (no impact, the migration only affects DB privileges).
- Once merged and deployed to dev, retry the curl from the failing report; should return \`{ \"nextInternalId\": \"...\" }\`.

— claude-opus-4-7