### PR TITLE
Fix MCP report tools failing with `argument "content" is null`

### DIFF
--- a/src/main/java/com/entropyteam/entropay/common/ReactAdminMapper.java
+++ b/src/main/java/com/entropyteam/entropay/common/ReactAdminMapper.java
@@ -153,6 +153,13 @@ public class ReactAdminMapper {
 
     public <T> Comparator<T> getComparator(ReactAdminParams params, Class<T> clazz) {
 
+        // React Admin always sends sort, but programmatic callers (e.g. the MCP report tools)
+        // may not. Mirror buildPageable()'s null-guard: no sort means keep the incoming order
+        // rather than letting Jackson reject the null payload.
+        if (params.getSort() == null) {
+            return (object1, object2) -> 0;
+        }
+
         return (object1, object2) -> {
             try {
                 List<String> sortList = mapper.readValue(params.getSort(), List.class);
@@ -237,6 +244,11 @@ public class ReactAdminMapper {
     }
 
     private Map<String, String> parseFilters(ReactAdminParams params) {
+        // No filter means no constraints. Guard the null before it reaches Jackson, which
+        // rejects a null payload with IllegalArgumentException("argument \"content\" is null").
+        if (params.getFilter() == null) {
+            return new HashMap<>();
+        }
         Map<String, String> filters;
         try {
             filters = mapper.readValue(params.getFilter(), Map.class);
@@ -287,6 +299,12 @@ public class ReactAdminMapper {
 
 
     public Range<Integer> getRange(ReactAdminParams params) {
+        // No range means "return everything". Use a full, paginate()-safe range instead of
+        // letting Jackson reject the null payload. The upper bound stays below Integer.MAX_VALUE
+        // because paginate() computes getMaximum() + 1, which would overflow at MAX_VALUE.
+        if (params.getRange() == null) {
+            return Range.of(0, Integer.MAX_VALUE - 1);
+        }
         try {
             List<Integer> rangeList = mapper.readValue(params.getRange(), List.class);
             Integer start = rangeList.get(0);
@@ -309,15 +327,29 @@ public class ReactAdminMapper {
     @SuppressWarnings("unchecked")
     public ReactAdminSqlParams map(ReactAdminParams params) {
         try {
-            String[] array = mapper.readValue(params.getSort(), String[].class);
-            String sort = array[0];
-            String order = array[1];
+            // React Admin always sends sort/range/filter, but programmatic callers (e.g. the MCP
+            // report tools) may omit them. Guard each before it reaches Jackson, which rejects a
+            // null payload with IllegalArgumentException("argument \"content\" is null"). Mirrors
+            // the existing null-guards in buildPageable()/buildFilter().
+            String sort = null;
+            String order = null;
+            if (params.getSort() != null) {
+                String[] array = mapper.readValue(params.getSort(), String[].class);
+                sort = array[0];
+                order = array[1];
+            }
 
-            int[] range = mapper.readValue(params.getRange(), int[].class);
-            int limit = range[1] - range[0] + 1;
-            int offset = range[0];
+            int offset = 0;
+            int limit = Integer.MAX_VALUE;
+            if (params.getRange() != null) {
+                int[] range = mapper.readValue(params.getRange(), int[].class);
+                offset = range[0];
+                limit = range[1] - range[0] + 1;
+            }
 
-            Map<String, String> queryParameters = mapper.readValue(params.getFilter(), Map.class);
+            Map<String, String> queryParameters = params.getFilter() == null
+                    ? new HashMap<>()
+                    : mapper.readValue(params.getFilter(), Map.class);
 
             return new ReactAdminSqlParams(queryParameters, limit, offset, sort, order);
         } catch (JsonProcessingException e) {

--- a/src/test/java/com/entropyteam/entropay/employees/common/ReactAdminMapperTest.java
+++ b/src/test/java/com/entropyteam/entropay/employees/common/ReactAdminMapperTest.java
@@ -2,6 +2,7 @@ package com.entropyteam.entropay.employees.common;
 
 import java.util.List;
 import java.util.UUID;
+import org.apache.commons.lang3.Range;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,6 +13,8 @@ import org.springframework.data.domain.Sort.Order;
 import com.entropyteam.entropay.common.Filter;
 import com.entropyteam.entropay.common.ReactAdminMapper;
 import com.entropyteam.entropay.common.ReactAdminParams;
+import com.entropyteam.entropay.common.ReactAdminSqlParams;
+import com.entropyteam.entropay.employees.dtos.ReportDto;
 import com.entropyteam.entropay.employees.models.Contract;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -97,5 +100,67 @@ public class ReactAdminMapperTest {
         Sort sort = pageable.getSort();
         List<Order> orderList = sort.stream().toList();
         Assertions.assertEquals(0, orderList.size());
+    }
+
+    // --- Regression: programmatic callers (e.g. the MCP report tools) build a ReactAdminParams
+    // without sort/range — React Admin always sends them, but those callers do not. Before the
+    // null-guards, map()/paginate()/getRange()/getComparator() handed the null straight to
+    // Jackson's readValue, which throws IllegalArgumentException: argument "content" is null —
+    // the exact error the four report tools returned in QA. ---
+
+    private record Row(UUID id, String name) {
+    }
+
+    @Test
+    public void mapToleratesAllNullParams() {
+        // The get_salaries_report tool calls map() with new ReactAdminParams() (filter/range/sort null).
+        ReactAdminSqlParams sqlParams = mapper.map(new ReactAdminParams());
+
+        Assertions.assertTrue(sqlParams.queryParameters().isEmpty());
+        Assertions.assertEquals(0, sqlParams.offset());
+        Assertions.assertNull(sqlParams.sort());
+        Assertions.assertNull(sqlParams.order());
+    }
+
+    @Test
+    public void mapToleratesFilterOnlyParams() {
+        // The billing/margin/turnover tools set only the date filter, leaving sort/range null.
+        ReactAdminParams params =
+                new ReactAdminParams("{\"startDate\":\"2026-01-01\",\"endDate\":\"2026-05-31\"}", null, null);
+
+        ReactAdminSqlParams sqlParams = mapper.map(params);
+
+        Assertions.assertEquals("2026-01-01", sqlParams.queryParameters().get("startDate"));
+        Assertions.assertEquals("2026-05-31", sqlParams.queryParameters().get("endDate"));
+    }
+
+    @Test
+    public void paginateToleratesNullSortRangeAndFilter() {
+        // salaries/billing/margin then flow through paginate(), which also parsed sort/range/filter.
+        List<Row> rows = List.of(new Row(UUID.randomUUID(), "a"), new Row(UUID.randomUUID(), "b"));
+
+        ReportDto<Row> result = mapper.paginate(new ReactAdminParams(), rows, Row.class);
+
+        Assertions.assertEquals(2, result.size());
+        Assertions.assertEquals(2, result.data().size());
+    }
+
+    @Test
+    public void paginateWithNullParamsOnEmptyInputYieldsEmptyStructureNotNull() {
+        // "report sin filas" must yield an empty structure, never null.
+        ReportDto<Row> result = mapper.paginate(new ReactAdminParams(), List.of(), Row.class);
+
+        Assertions.assertEquals(0, result.size());
+        Assertions.assertNotNull(result.data());
+        Assertions.assertTrue(result.data().isEmpty());
+    }
+
+    @Test
+    public void getRangeWithNullRangeReturnsFullPaginateSafeRange() {
+        Range<Integer> range = mapper.getRange(new ReactAdminParams());
+
+        Assertions.assertEquals(0, range.getMinimum());
+        // Stays below Integer.MAX_VALUE so paginate()'s getMaximum() + 1 does not overflow.
+        Assertions.assertEquals(Integer.MAX_VALUE - 1, range.getMaximum());
     }
 }


### PR DESCRIPTION
## Problem

The four report MCP tools — `get_salaries_report`, `get_billing_report`, `get_margin_report`, `get_turnover_report` — failed in QA with `argument "content" is null`, while the other nine tools worked. This blocked promotion to Prod.

## Root cause

It was **not** permissions, empty data, or response serialization. It was an `IllegalArgumentException` thrown **during tool execution**, which Spring AI catches and returns as the tool result text — so the MCP client saw the raw message.

The four tools build a `ReactAdminParams` **without `sort`/`range`** (`get_salaries_report` builds an empty one; the date reports set only `filter`). React Admin always sends `sort`/`range`/`filter`, but these programmatic callers don't. `ReactAdminMapper.map()`/`paginate()` handed the null payload straight to Jackson's `readValue(String, …)`, which (since Jackson 2.13) rejects null with:

```
java.lang.IllegalArgumentException: argument "content" is null
```

Reproduced in isolation against the exact `jackson-databind 2.19.2` on the classpath — it returns that string verbatim.

The other nine tools work because they don't go through `ReactAdminMapper`; the REST API works because React Admin always sends the params.

## Fix

Null-guards on the four `readValue` entry points the report path hits, consistent with the guards already present in `buildPageable()`/`buildFilter()`:

- `map()` — null `sort`/`range`/`filter` → unsorted / unpaged / empty filter
- `getComparator()` — null `sort` → no-op comparator (preserves input order)
- `getRange()` — null `range` → full, `paginate()`-safe range (`MAX_VALUE - 1` avoids the `getMaximum() + 1` overflow)
- `parseFilters()` — null `filter` → empty map

REST is unaffected — it always sends the params, so the guards only trigger on null.

## Why existing tests missed it

`ReportsQueryServiceTest` **mocks** the four report services, so the real `ReactAdminMapper` never ran with the MCP-shaped params. The bug lived at the MCP↔mapper boundary that no test exercised.

Added regression tests that run the **real** `ReactAdminMapper` with the partial/empty params the MCP tools build, including the "report with no rows → empty structure, not null" case.

## Testing

- `ReactAdminMapperTest`: 9/9 (4 existing + 5 new)
- Full MCP + masking + mapper + report-service suites: **53/53 green**

## Not included

Secondary, non-blocking bug: `get_employee`/`get_employee_summary` full-name search (`"Agustin Bourgeois"` fails, `"Bourgeois"` works) — the shared `q` search matches per-column and doesn't concatenate first+last. Lives in the REST search path; to be handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)