### PR TITLE
Add date filters and status/details to PTO reports

### DIFF
--- a/src/main/java/com/entropyteam/entropay/common/ReactAdminMapper.java
+++ b/src/main/java/com/entropyteam/entropay/common/ReactAdminMapper.java
@@ -136,7 +136,10 @@ public class ReactAdminMapper {
             if (params.getFilter() != null) {
                 Map<String, Object> requestFilter = mapper.readValue(params.getFilter(), Map.class);
                 for (Map.Entry<String, Object> filter : requestFilter.entrySet()) {
-                    if (isEntityField(report, filter.getKey())) {
+                    if (isEntityField(report, filter.getKey())
+                        || StringUtils.equalsIgnoreCase(filter.getKey(), YEAR_SEARCH_TERM_KEY)
+                        || StringUtils.equalsIgnoreCase(filter.getKey(), DATE_FROM_TERM_KEY)
+                        || StringUtils.equalsIgnoreCase(filter.getKey(), DATE_TO_TERM_KEY)) {
                         getByFieldsFilter.put(filter.getKey(), filter.getValue());
                     }
                 }

--- a/src/main/java/com/entropyteam/entropay/employees/dtos/PtoReportDetailDto.java
+++ b/src/main/java/com/entropyteam/entropay/employees/dtos/PtoReportDetailDto.java
@@ -19,9 +19,11 @@ public class PtoReportDetailDto {
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate endDate;
     private Integer year;
+    private String status;
+    private String details;
 
     public PtoReportDetailDto(UUID id, UUID employeeId, String internalId, String firstName, String lastName, String clientName, String leaveTypeName, Double days, UUID clientId,
-                              LocalDate startDate, LocalDate endDate, Integer year) {
+                              LocalDate startDate, LocalDate endDate, Integer year, String status, String details) {
         this.id = id;
         this.employeeId = employeeId;
         this.internalId = internalId;
@@ -33,8 +35,8 @@ public class PtoReportDetailDto {
         this.clientId = clientId;
         this.startDate = startDate;
         this.endDate = endDate;
-        this.year = year;
-    }
+        this.year = year;        this.status = status;
+        this.details = details;    }
 
     public void setId(UUID id) {
         this.id = id;
@@ -130,5 +132,21 @@ public class PtoReportDetailDto {
 
     public Integer getYear() {
         return year;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getDetails() {
+        return details;
+    }
+
+    public void setDetails(String details) {
+        this.details = details;
     }
 }

--- a/src/main/java/com/entropyteam/entropay/employees/services/ReportService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/services/ReportService.java
@@ -58,6 +58,8 @@ public class ReportService {
     private final static String EMPLOYEE_ID = "employeeId";
     private final static String CLIENT_ID = "clientId";
     private final static String YEAR = "year";
+        private final static String DATE_FROM = "dateFrom";
+        private final static String DATE_TO = "dateTo";
     private final static String NO_CLIENT = "noClient";
     private final ReactAdminMapper mapper;
     private final RoleRepository roleRepository;
@@ -153,22 +155,21 @@ public class ReportService {
     public Page<PtoReportDetailDto> getPtoReportDetail(ReactAdminParams params) {
         List<PtoReportDetailDto> ptoReportDetailDtoList;
         Filter filter = mapper.buildReportFilter(params, PtoReportDetailDto.class);
-        Integer year = getYearFromFilter(filter);
         if (filter.getGetByFieldsFilter().containsKey(EMPLOYEE_ID)) {
             ptoReportDetailDtoList = getPtoReportDetailByEmployee(employeeRepository.findById(
-                    UUID.fromString((String) filter.getGetByFieldsFilter().get(EMPLOYEE_ID))).orElseThrow(), year);
+                                        UUID.fromString((String) filter.getGetByFieldsFilter().get(EMPLOYEE_ID))).orElseThrow(), filter);
         } else if (filter.getGetByFieldsFilter().containsKey(CLIENT_ID)) {
             Client client = (filter.getGetByFieldsFilter().get(CLIENT_ID)).equals(NO_CLIENT) ? null :
                     clientRepository.findById(UUID.fromString((String) filter.getGetByFieldsFilter().get(CLIENT_ID)))
                             .orElseThrow();
-            ptoReportDetailDtoList = getPtoReportDetailByClient(client, year);
+                        ptoReportDetailDtoList = getPtoReportDetailByClient(client, filter);
         } else {
             ptoReportDetailDtoList = Collections.emptyList();
         }
         return new PageImpl<>(ptoReportDetailDtoList, Pageable.unpaged(), ptoReportDetailDtoList.size());
     }
 
-    public List<PtoReportDetailDto> getPtoReportDetailByEmployee(Employee employee, Integer year) {
+        public List<PtoReportDetailDto> getPtoReportDetailByEmployee(Employee employee, Filter filter) {
         List<PtoReportDetailDto> ptoReportDetailDtoList;
 
         List<Assignment> employeesAssignments =
@@ -177,7 +178,11 @@ public class ReportService {
         UUID clientId = lastAssignment.map(assignment -> assignment.getProject().getClient().getId()).orElse(null);
         String clientName =
                 lastAssignment.map(assignment -> assignment.getProject().getClient().getName()).orElse("No client");
-        List<Pto> employeesPtosList = ptoRepository.findPtosByEmployeeIdIsAndDeletedIsFalse(employee.getId(), year);
+        List<Pto> employeesPtosList = ptoRepository.findAllByDeletedIsFalseAndStatusIs(Status.APPROVED)
+                .stream()
+                .filter(pto -> pto.getEmployee().getId().equals(employee.getId()))
+                .filter(pto -> matchesDateFilter(pto, filter))
+                .toList();
 
         ptoReportDetailDtoList = employeesPtosList.stream()
                 .sorted(Comparator.comparing(Pto::getStartDate))
@@ -194,14 +199,16 @@ public class ReportService {
                         clientId,
                         pto.getStartDate(),
                         pto.getEndDate(),
-                        year
+                        getDisplayYear(filter, pto),
+                        pto.getStatus().name(),
+                        pto.getDetails()
                 ))
                 .collect(Collectors.toList());
 
         return ptoReportDetailDtoList;
     }
 
-    public List<PtoReportDetailDto> getPtoReportDetailByClient(Client client, Integer year) {
+        public List<PtoReportDetailDto> getPtoReportDetailByClient(Client client, Filter filter) {
         List<PtoReportDetailDto> ptoReportDetailDtoList;
         List<Employee> employeeList;
         if (client != null) {
@@ -211,9 +218,12 @@ public class ReportService {
         } else {
             employeeList = employeeRepository.findAllUnassignedEmployees();
         }
-        List<Pto> employeesPtoList =
-                ptoRepository.findPtosByEmployeeIdInAndForYear(employeeList.stream().map(BaseEntity::getId).toList(),
-                        year);
+        List<UUID> employeeIds = employeeList.stream().map(BaseEntity::getId).toList();
+        List<Pto> employeesPtoList = ptoRepository.findAllByDeletedIsFalseAndStatusIs(Status.APPROVED)
+                .stream()
+                .filter(pto -> employeeIds.contains(pto.getEmployee().getId()))
+                .filter(pto -> matchesDateFilter(pto, filter))
+                .toList();
 
         ptoReportDetailDtoList = employeesPtoList.stream()
                 .sorted(Comparator.comparing(Pto::getStartDate))
@@ -232,7 +242,9 @@ public class ReportService {
                             client != null ? client.getId() : null,
                             pto.getStartDate(),
                             pto.getEndDate(),
-                            year
+                            getDisplayYear(filter, pto),
+                            pto.getStatus().name(),
+                            pto.getDetails()
                     );
                 })
                 .collect(Collectors.toList());
@@ -243,12 +255,8 @@ public class ReportService {
     public Page<PtoReportEmployeeDto> getPtosReportByEmployees(ReactAdminParams params) {
         List<PtoReportEmployeeDto> ptoReportDtoList;
         Filter filter = mapper.buildReportFilter(params, PtoReportEmployeeDto.class);
-        int year = LocalDate.now().getYear();
-        if (filter.getGetByFieldsFilter().containsKey(YEAR)) {
-            year = getYearFromFilter(filter);
-        }
-        ptoReportDtoList = getPtoReportEmployeeDtos(
-                ptoRepository.findAllByDeletedIsFalseAndStatusIsForYear(Status.APPROVED.name(), year), year);
+                Integer year = getYearFromFilter(filter);
+                ptoReportDtoList = getPtoReportEmployeeDtos(getFilteredPtos(filter), year);
         return new PageImpl<>(ptoReportDtoList, Pageable.unpaged(), ptoReportDtoList.size());
     }
 
@@ -288,12 +296,8 @@ public class ReportService {
     public Page<PtoReportClientDto> getPtosReportByClients(ReactAdminParams params) {
         List<PtoReportClientDto> ptoReportDtoList;
         Filter filter = mapper.buildReportFilter(params, PtoReportClientDto.class);
-        int year = LocalDate.now().getYear();
-        if (filter.getGetByFieldsFilter().containsKey(YEAR)) {
-            year = getYearFromFilter(filter);
-        }
-        ptoReportDtoList = getPtoReportClientDtos(
-                ptoRepository.findAllByDeletedIsFalseAndStatusIsForYear(Status.APPROVED.name(), year), year);
+                Integer year = getYearFromFilter(filter);
+                ptoReportDtoList = getPtoReportClientDtos(getFilteredPtos(filter), year);
         return new PageImpl<>(ptoReportDtoList, Pageable.unpaged(), ptoReportDtoList.size());
     }
 
@@ -327,21 +331,82 @@ public class ReportService {
 
     public Page<PtoReportDetailDto> getPtoReportAllDetails(ReactAdminParams params) {
         Filter filter = mapper.buildReportFilter(params, PtoReportDetailDto.class);
-        Integer year = getYearFromFilter(filter);
-        List<PtoReportDetailDto> ptoReportDetailDtoList = getPtoReportAllDetailsDto(year);
+                List<PtoReportDetailDto> ptoReportDetailDtoList = getPtoReportAllDetailsDto(filter);
         return new PageImpl<>(ptoReportDetailDtoList, Pageable.unpaged(), ptoReportDetailDtoList.size());
     }
 
-    private List<PtoReportDetailDto> getPtoReportAllDetailsDto(Integer year) {
+        private List<PtoReportDetailDto> getPtoReportAllDetailsDto(Filter filter) {
         return employeeRepository.findAllByDeletedIsFalseAndActiveIsTrue().stream()
-                .flatMap(employee -> getPtoReportDetailByEmployee(employee, year).stream())
+                                .flatMap(employee -> getPtoReportDetailByEmployee(employee, filter).stream())
                 .collect(Collectors.toList());
     }
 
     private Integer getYearFromFilter(Filter filter) {
         Object yearObject = filter.getGetByFieldsFilter().get(YEAR);
+                if (yearObject == null || yearObject.toString().isBlank()) {
+                        return null;
+                }
         return Integer.parseInt(yearObject.toString());
     }
+
+        private int getDisplayYear(Filter filter, Pto pto) {
+                Integer year = getYearFromFilter(filter);
+                if (year != null) {
+                        return year;
+                }
+
+                return pto.getStartDate().getYear();
+        }
+
+        private List<Pto> getFilteredPtos(Filter filter) {
+                List<Pto> approvedPtos = ptoRepository.findAllByDeletedIsFalseAndStatusIs(Status.APPROVED);
+                return approvedPtos.stream().filter(pto -> matchesDateFilter(pto, filter)).toList();
+        }
+
+        private boolean matchesDateFilter(Pto pto, Filter filter) {
+                LocalDate dateFrom = getDateFrom(filter);
+                LocalDate dateTo = getDateTo(filter);
+
+                if (dateFrom == null && dateTo == null) {
+                        Integer year = getYearFromFilter(filter);
+                        if (year == null) {
+                                return true;
+                        }
+                        return pto.getStartDate().getYear() == year || pto.getEndDate().getYear() == year;
+                }
+
+                LocalDate normalizedFrom = dateFrom != null ? dateFrom : dateTo;
+                LocalDate normalizedTo = dateTo != null ? dateTo : dateFrom;
+
+                if (normalizedFrom.isAfter(normalizedTo)) {
+                        LocalDate tmp = normalizedFrom;
+                        normalizedFrom = normalizedTo;
+                        normalizedTo = tmp;
+                }
+
+                return isDateBetween(pto.getStartDate(), normalizedFrom, normalizedTo)
+                                   || isDateBetween(pto.getEndDate(), normalizedFrom, normalizedTo);
+        }
+
+        private LocalDate getDateFrom(Filter filter) {
+                Object dateFrom = filter.getGetByFieldsFilter().get(DATE_FROM);
+                if (dateFrom == null) {
+                        return null;
+                }
+                return LocalDate.parse(dateFrom.toString());
+        }
+
+        private LocalDate getDateTo(Filter filter) {
+                Object dateTo = filter.getGetByFieldsFilter().get(DATE_TO);
+                if (dateTo == null) {
+                        return null;
+                }
+                return LocalDate.parse(dateTo.toString());
+        }
+
+        private boolean isDateBetween(LocalDate value, LocalDate from, LocalDate to) {
+                return (value.isEqual(from) || value.isAfter(from)) && (value.isEqual(to) || value.isBefore(to));
+        }
 
     public ReportDto<SalariesReportDto> getSalariesReport(ReactAdminParams params) {
         LOGGER.info("Getting salaries report with params: {}", params);


### PR DESCRIPTION
Enable date-range filtering and include PTO status/details in report DTOs. ReactAdminMapper now accepts YEAR, dateFrom and dateTo as valid filter keys. PtoReportDetailDto gains status and details fields (with constructor and accessors). ReportService was refactored: added DATE_FROM/DATE_TO constants, updated report methods to accept Filter objects, limited queries to approved PTOs and applied date-range or year-based filtering, and added helper methods (getDateFrom/getDateTo/matchesDateFilter/getFilteredPtos/getDisplayYear/isDateBetween). Also handle blank year as null. These changes allow generating PTO reports by date ranges or year while exposing PTO status and details in the output.

# Description :pencil:

This pull request enhances the PTO (Paid Time Off) report functionality by adding support for date range filtering, improving filter handling, and expanding the detail available in PTO report DTOs. The changes also refactor the service methods to be more flexible and robust, especially in handling various filter scenarios.

Key changes include:

**Filtering and Query Improvements:**

* Added support for filtering PTO reports by date range (`dateFrom`, `dateTo`) in addition to year, and refactored filter handling logic to allow for more flexible queries. The filter now supports year, dateFrom, and dateTo keys, and the service methods use these to filter PTOs accordingly. [[1]](diffhunk://#diff-c78598dc70e69b6890fedb9aa3e60a3e5cdfe997ab5b8115bc14a156189d125eL139-R142) [[2]](diffhunk://#diff-6f3b866c64e808cd7bbb63fccc2cd66e0a091e785a5540181d1bf52e63446e9cR61-R62) [[3]](diffhunk://#diff-6f3b866c64e808cd7bbb63fccc2cd66e0a091e785a5540181d1bf52e63446e9cL156-R172) [[4]](diffhunk://#diff-6f3b866c64e808cd7bbb63fccc2cd66e0a091e785a5540181d1bf52e63446e9cL180-R185) [[5]](diffhunk://#diff-6f3b866c64e808cd7bbb63fccc2cd66e0a091e785a5540181d1bf52e63446e9cL214-R226) [[6]](diffhunk://#diff-6f3b866c64e808cd7bbb63fccc2cd66e0a091e785a5540181d1bf52e63446e9cL246-R259) [[7]](diffhunk://#diff-6f3b866c64e808cd7bbb63fccc2cd66e0a091e785a5540181d1bf52e63446e9cL330-R410) [[8]](diffhunk://#diff-6f3b866c64e808cd7bbb63fccc2cd66e0a091e785a5540181d1bf52e63446e9cL291-R300)

* Introduced new helper methods in `ReportService` for extracting and applying date and year filters, including `getYearFromFilter`, `getDisplayYear`, `getFilteredPtos`, and `matchesDateFilter`, ensuring consistent and accurate filtering across different report endpoints.

**DTO and Data Enrichment:**

* Extended `PtoReportDetailDto` to include `status` and `details` fields, updated its constructor and added corresponding getters/setters, allowing reports to return more comprehensive PTO details. [[1]](diffhunk://#diff-3cb7786f9e3a0ace17389ab121853243642db37d6a468a73dab0c527635dba6dR22-R26) [[2]](diffhunk://#diff-3cb7786f9e3a0ace17389ab121853243642db37d6a468a73dab0c527635dba6dL36-R39) [[3]](diffhunk://#diff-3cb7786f9e3a0ace17389ab121853243642db37d6a468a73dab0c527635dba6dR136-R151) [[4]](diffhunk://#diff-6f3b866c64e808cd7bbb63fccc2cd66e0a091e785a5540181d1bf52e63446e9cL197-R211) [[5]](diffhunk://#diff-6f3b866c64e808cd7bbb63fccc2cd66e0a091e785a5540181d1bf52e63446e9cL235-R247)

These changes collectively make PTO reporting more powerful and user-friendly, supporting more advanced filtering and richer data in the report outputs.

## Link to ticket :link:

[https://app.basecamp.com/5776473/buckets/37034902/card_tables/cards/7363517251](https://app.basecamp.com/5776473/buckets/37034902/card_tables/cards/7363517251)