### PR TITLE
[employees] Recognize hourly contract cost in employee salary/margin and margin report

### DIFF
--- a/src/main/java/com/entropyteam/entropay/employees/dtos/EmployeeDto.java
+++ b/src/main/java/com/entropyteam/entropay/employees/dtos/EmployeeDto.java
@@ -139,7 +139,7 @@ public final class EmployeeDto implements EmployeeIdAware {
         this.nearestPto = employee.getNearestPto(LocalDate.now());
         this.timeSinceStart = timeSinceStart;
         this.countryName = employee.getCountry().getName();
-        this.salary = activeContract != null ? activeContract.calculateMonthlySalaryInUSD() : BigDecimal.ZERO;
+        this.salary = activeContract != null ? MarginService.monthlyCostInUSD(activeContract) : BigDecimal.ZERO;
         this.rate = lastAssignment != null ? lastAssignment.getBillableRate() : BigDecimal.ZERO;
         this.margin = MarginService.calculateMargin(salary, rate);
         this.hasChildren = employee.isHasChildren();

--- a/src/main/java/com/entropyteam/entropay/employees/models/Contract.java
+++ b/src/main/java/com/entropyteam/entropay/employees/models/Contract.java
@@ -222,6 +222,24 @@ public class Contract extends BaseEntity {
         return BigDecimal.ZERO;
     }
 
+    /**
+     * Per-month hourly cost for this contract, for every month it is active within the given range.
+     * The value is the employee's hourly cost (the {@code HOUR}/{@code USD} settlement salary), constant
+     * across months; the margin report multiplies it by the hours actually worked that month.
+     *
+     * @return a map of {@code YearMonth -> hourly cost}, or an empty map when the contract has no
+     *         hourly cost (e.g. a monthly contract).
+     */
+    public Map<YearMonth, BigDecimal> getHourlyCostByMonth(LocalDate startDate, LocalDate endDate) {
+        BigDecimal hourlyCost = calculateHourlyCostInUSD();
+        if (hourlyCost.signum() == 0) {
+            return Map.of();
+        }
+        return generatePeriod(startDate, endDate)
+                .stream()
+                .collect(Collectors.toMap(Function.identity(), yearMonth -> hourlyCost, (a, b) -> b));
+    }
+
     private List<YearMonth> generatePeriod(LocalDate startDate, LocalDate endDate) {
         YearMonth start =
                 startDate.isAfter(this.startDate) ? YearMonth.from(startDate) : YearMonth.from(this.startDate);
@@ -248,6 +266,22 @@ public class Contract extends BaseEntity {
     public BigDecimal calculateMonthlySalaryInUSD() {
         return paymentsSettlement.stream()
                 .filter(payment -> Modality.MONTHLY.equals(payment.getModality()))
+                .filter(payment -> Currency.USD.equals(payment.getCurrency()))
+                .map(PaymentSettlement::getSalary)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    /**
+     * Cumulative hourly cost in USD for all payment settlements with modality {@code HOUR} and
+     * currency {@code USD}. For an hourly contract the settlement salary stores the employee's
+     * cost per hour (see {@code PayrollCalculatorService#computeHourlyRate}).
+     *
+     * @return the total hourly cost as a {@code BigDecimal}, or {@code BigDecimal.ZERO} when there
+     *         is no matching hourly settlement.
+     */
+    public BigDecimal calculateHourlyCostInUSD() {
+        return paymentsSettlement.stream()
+                .filter(payment -> Modality.HOUR.equals(payment.getModality()))
                 .filter(payment -> Currency.USD.equals(payment.getCurrency()))
                 .map(PaymentSettlement::getSalary)
                 .reduce(BigDecimal.ZERO, BigDecimal::add);

--- a/src/main/java/com/entropyteam/entropay/employees/services/MarginService.java
+++ b/src/main/java/com/entropyteam/entropay/employees/services/MarginService.java
@@ -23,6 +23,7 @@ import com.entropyteam.entropay.common.sensitiveInformation.EmployeeIdAware;
 import com.entropyteam.entropay.common.sensitiveInformation.SensitiveInformation;
 import com.entropyteam.entropay.employees.dtos.ReportDto;
 import com.entropyteam.entropay.employees.models.Assignment;
+import com.entropyteam.entropay.employees.models.Contract;
 import com.entropyteam.entropay.employees.models.Employee;
 import com.entropyteam.entropay.employees.models.Overtime;
 import com.entropyteam.entropay.employees.timetracking.AssignmentTimeEntry;
@@ -36,6 +37,11 @@ import jakarta.validation.constraints.NotNull;
 public class MarginService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MarginService.class);
+    /** Annual billable hours used as the revenue basis: {@code annualRevenue = rate × 1850}. */
+    private static final BigDecimal ANNUAL_BILLABLE_HOURS = BigDecimal.valueOf(1850);
+    /** Months per year used to annualize a monthly cost: {@code annualCost = monthlySalary × 12}. */
+    private static final BigDecimal MONTHS_PER_YEAR = BigDecimal.valueOf(12);
+    private static final int MONEY_SCALE = 2;
     private final PtoService ptoService;
     private final OvertimeService overtimeService;
     private final AssignmentService assignmentService;
@@ -93,6 +99,7 @@ public class MarginService {
         LOGGER.info("Generating margin for period {} - {}", startDate, endDate);
 
         Map<EmployeeMonthly, BigDecimal> salaries = getSalaries(startDate, endDate);
+        Map<EmployeeMonthly, BigDecimal> hourlyCosts = getHourlyCosts(startDate, endDate);
         Map<EmployeeMonthly, Double> ptoHours = getPtoHours(startDate, endDate);
 
         Map<MonthlyAssignment, List<TimeTrackingEntry>> timeTrackingByAssignment =
@@ -108,10 +115,17 @@ public class MarginService {
         List<MarginDto> report = new ArrayList<>();
         timeTrackingByAssignment.forEach((key, value) -> {
             EmployeeMonthly employeeMonthly = new EmployeeMonthly(key.assignment().getEmployee(), key.month());
-            BigDecimal salary = salaries.get(employeeMonthly);
             Double ptoHoursValue = ptoHours.getOrDefault(employeeMonthly, 0.0);
             Double hours = value.stream().map(TimeTrackingEntry::getHours).reduce(Double::sum).orElse(0.0);
             BigDecimal rate = key.assignment.getBillableRate();
+
+            // Hourly contracts: the monthly cost is the hourly cost times the hours actually worked
+            // (net of PTO), the same basis as `total`, so a pass-through engagement nets to 0% margin.
+            // Monthly contracts keep their precomputed salary untouched.
+            BigDecimal hourlyCost = hourlyCosts.get(employeeMonthly);
+            BigDecimal salary = hourlyCost != null
+                    ? hourlyCost.multiply(BigDecimal.valueOf(hours - ptoHoursValue))
+                    : salaries.get(employeeMonthly);
 
             report.add(getMarginDto(key, rate, hours, ptoHoursValue, salary));
         });
@@ -154,16 +168,54 @@ public class MarginService {
         return salaries;
     }
 
+    private Map<EmployeeMonthly, BigDecimal> getHourlyCosts(LocalDate startDate, LocalDate endDate) {
+        Map<EmployeeMonthly, BigDecimal> hourlyCosts = new HashMap<>();
+
+        contractService.findByDateBetween(startDate, endDate)
+                .forEach(contract -> {
+                    Map<YearMonth, BigDecimal> costByMonth = contract.getHourlyCostByMonth(startDate, endDate);
+                    costByMonth.forEach((yearMonth, hourlyCost) -> {
+                        EmployeeMonthly key = new EmployeeMonthly(contract.getEmployee(), yearMonth);
+                        hourlyCosts.merge(key, hourlyCost, BigDecimal::add);
+                    });
+                });
+
+        return hourlyCosts;
+    }
+
     public static BigDecimal calculateMargin(@NotNull BigDecimal salary, @NotNull BigDecimal rate) {
         if (rate.compareTo(BigDecimal.ZERO) == 0) {
             return BigDecimal.ZERO;
         }
 
-        BigDecimal annualRevenue = rate.multiply(BigDecimal.valueOf(1850));
-        BigDecimal annualCost = salary.multiply(BigDecimal.valueOf(12));
+        BigDecimal annualRevenue = rate.multiply(ANNUAL_BILLABLE_HOURS);
+        BigDecimal annualCost = salary.multiply(MONTHS_PER_YEAR);
         BigDecimal grossMargin = annualRevenue.subtract(annualCost);
         BigDecimal marginPercentage = grossMargin.divide(annualRevenue, 2, RoundingMode.HALF_UP);
 
         return marginPercentage.multiply(BigDecimal.valueOf(100));
+    }
+
+    /**
+     * Monthly cost in USD for the employee card and detail header. Monthly contracts return their
+     * monthly salary unchanged. For an hourly contract — whose monthly salary is zero — the hourly
+     * cost is scaled to a monthly equivalent on the same annualized basis {@link #calculateMargin}
+     * uses, so that {@code annualCost = hourlyCost × ANNUAL_BILLABLE_HOURS}. This makes a pass-through
+     * engagement (hourly cost equal to the billed rate) yield a 0% margin instead of 100%.
+     *
+     * @return the monthly cost in USD, or {@code BigDecimal.ZERO} when neither a monthly salary nor
+     *         an hourly cost is present.
+     */
+    public static BigDecimal monthlyCostInUSD(@NotNull Contract contract) {
+        BigDecimal monthlySalary = contract.calculateMonthlySalaryInUSD();
+        if (monthlySalary.signum() != 0) {
+            return monthlySalary;
+        }
+        BigDecimal hourlyCost = contract.calculateHourlyCostInUSD();
+        if (hourlyCost.signum() == 0) {
+            return BigDecimal.ZERO;
+        }
+        return hourlyCost.multiply(ANNUAL_BILLABLE_HOURS)
+                .divide(MONTHS_PER_YEAR, MONEY_SCALE, RoundingMode.HALF_UP);
     }
 }

--- a/src/test/java/com/entropyteam/entropay/employees/models/ContractTest.java
+++ b/src/test/java/com/entropyteam/entropay/employees/models/ContractTest.java
@@ -1,0 +1,84 @@
+package com.entropyteam.entropay.employees.models;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ContractTest {
+
+    private static Contract contractWith(PaymentSettlement... settlements) {
+        Contract contract = new Contract();
+        contract.setStartDate(LocalDate.of(2024, 1, 1));
+        for (PaymentSettlement settlement : settlements) {
+            contract.addPaymentSettlement(settlement);
+        }
+        return contract;
+    }
+
+    private static PaymentSettlement settlement(Modality modality, Currency currency, BigDecimal salary) {
+        PaymentSettlement settlement = new PaymentSettlement();
+        settlement.setModality(modality);
+        settlement.setCurrency(currency);
+        settlement.setSalary(salary);
+        return settlement;
+    }
+
+    @DisplayName("calculateMonthlySalaryInUSD sums only MONTHLY/USD settlements (unchanged)")
+    @Test
+    void calculateMonthlySalaryInUSD_monthlyUsd() {
+        Contract contract = contractWith(settlement(Modality.MONTHLY, Currency.USD, BigDecimal.valueOf(2300)));
+
+        Assertions.assertEquals(BigDecimal.valueOf(2300), contract.calculateMonthlySalaryInUSD());
+    }
+
+    @DisplayName("calculateMonthlySalaryInUSD ignores HOUR settlements")
+    @Test
+    void calculateMonthlySalaryInUSD_hourReturnsZero() {
+        Contract contract = contractWith(settlement(Modality.HOUR, Currency.USD, BigDecimal.valueOf(60)));
+
+        Assertions.assertEquals(0, BigDecimal.ZERO.compareTo(contract.calculateMonthlySalaryInUSD()));
+    }
+
+    @DisplayName("calculateHourlyCostInUSD returns the HOUR/USD settlement salary as the hourly cost")
+    @Test
+    void calculateHourlyCostInUSD_hourUsd() {
+        Contract contract = contractWith(settlement(Modality.HOUR, Currency.USD, BigDecimal.valueOf(60)));
+
+        Assertions.assertEquals(BigDecimal.valueOf(60), contract.calculateHourlyCostInUSD());
+    }
+
+    @DisplayName("calculateHourlyCostInUSD returns zero for a monthly contract")
+    @Test
+    void calculateHourlyCostInUSD_monthlyReturnsZero() {
+        Contract contract = contractWith(settlement(Modality.MONTHLY, Currency.USD, BigDecimal.valueOf(2300)));
+
+        Assertions.assertEquals(0, BigDecimal.ZERO.compareTo(contract.calculateHourlyCostInUSD()));
+    }
+
+    @DisplayName("getHourlyCostByMonth repeats the hourly cost for every active month in range")
+    @Test
+    void getHourlyCostByMonth_hourly() {
+        Contract contract = contractWith(settlement(Modality.HOUR, Currency.USD, BigDecimal.valueOf(60)));
+
+        Map<YearMonth, BigDecimal> byMonth =
+                contract.getHourlyCostByMonth(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 3, 31));
+
+        Assertions.assertEquals(3, byMonth.size());
+        Assertions.assertEquals(BigDecimal.valueOf(60), byMonth.get(YearMonth.of(2024, 1)));
+        Assertions.assertEquals(BigDecimal.valueOf(60), byMonth.get(YearMonth.of(2024, 2)));
+        Assertions.assertEquals(BigDecimal.valueOf(60), byMonth.get(YearMonth.of(2024, 3)));
+    }
+
+    @DisplayName("getHourlyCostByMonth is empty for a monthly contract")
+    @Test
+    void getHourlyCostByMonth_monthlyIsEmpty() {
+        Contract contract = contractWith(settlement(Modality.MONTHLY, Currency.USD, BigDecimal.valueOf(2300)));
+
+        Assertions.assertTrue(
+                contract.getHourlyCostByMonth(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 3, 31)).isEmpty());
+    }
+}

--- a/src/test/java/com/entropyteam/entropay/employees/services/MarginServiceTest.java
+++ b/src/test/java/com/entropyteam/entropay/employees/services/MarginServiceTest.java
@@ -156,6 +156,121 @@ class MarginServiceTest {
         validateResult(data.get(15), YearMonth.of(2025, 4), rate2025, 160.0, 56d, BigDecimal.valueOf(2800));
     }
 
+    @Test
+    void testMonthlyCostInUSD_monthlyContractIsUnchanged() {
+        Contract contract = buildContract(buildEmployee(UUID.randomUUID(), "E010"),
+                LocalDate.of(2024, 1, 1), null, BigDecimal.valueOf(2300));
+
+        Assertions.assertEquals(BigDecimal.valueOf(2300), MarginService.monthlyCostInUSD(contract));
+    }
+
+    @Test
+    void testMonthlyCostInUSD_hourlyContractIsScaledToMonthlyEquivalent() {
+        Contract contract = buildHourlyContract(buildEmployee(UUID.randomUUID(), "E011"),
+                LocalDate.of(2024, 1, 1), null, BigDecimal.valueOf(60));
+
+        // hourlyCost (60) × 1850 annual hours / 12 months = 9250.00
+        Assertions.assertEquals(0,
+                new BigDecimal("9250.00").compareTo(MarginService.monthlyCostInUSD(contract)));
+    }
+
+    @Test
+    void testCalculateMargin_passThroughHourlyEngagementIsZero() {
+        Contract contract = buildHourlyContract(buildEmployee(UUID.randomUUID(), "E012"),
+                LocalDate.of(2024, 1, 1), null, BigDecimal.valueOf(60));
+        BigDecimal rate = BigDecimal.valueOf(60);
+
+        BigDecimal salary = MarginService.monthlyCostInUSD(contract);
+        BigDecimal margin = MarginService.calculateMargin(salary, rate);
+
+        Assertions.assertEquals(0, BigDecimal.ZERO.compareTo(margin));
+    }
+
+    @Test
+    void testCalculateMargin_hourlyCostBelowRateIsPositiveAndProportional() {
+        Contract contract = buildHourlyContract(buildEmployee(UUID.randomUUID(), "E013"),
+                LocalDate.of(2024, 1, 1), null, BigDecimal.valueOf(30));
+        BigDecimal rate = BigDecimal.valueOf(60);
+
+        BigDecimal salary = MarginService.monthlyCostInUSD(contract);
+        BigDecimal margin = MarginService.calculateMargin(salary, rate);
+
+        // cost 30 vs rate 60 → exactly half the revenue is cost → 50% margin
+        Assertions.assertEquals(0, BigDecimal.valueOf(50).compareTo(margin));
+    }
+
+    @Test
+    void testCalculateMargin_monthlyContractMarginIsUnchanged() {
+        // Regression: salary 5000, rate 60 → annualRevenue 111000, annualCost 60000 → 45.95% → 46%
+        BigDecimal margin = MarginService.calculateMargin(BigDecimal.valueOf(5000), BigDecimal.valueOf(60));
+
+        Assertions.assertEquals(0, BigDecimal.valueOf(46).compareTo(margin));
+    }
+
+    @Test
+    void testGenerateMarginReport_passThroughHourlyEmployeeHasZeroMargin() {
+        List<MarginDto> data = generateSingleMonthHourlyReport(BigDecimal.valueOf(60), BigDecimal.valueOf(60), "E020");
+
+        Assertions.assertEquals(1, data.size());
+        MarginDto dto = data.get(0);
+        // 5 weekdays in 2025-06-02..2025-06-06 × 8h = 40 billable hours
+        Assertions.assertEquals(40.0, dto.hours());
+        Assertions.assertEquals(0, dto.paid().compareTo(dto.total()));
+        Assertions.assertEquals(0, BigDecimal.ZERO.compareTo(dto.margin()));
+    }
+
+    @Test
+    void testGenerateMarginReport_hourlyCostBelowRateHasPositiveMargin() {
+        List<MarginDto> data = generateSingleMonthHourlyReport(BigDecimal.valueOf(30), BigDecimal.valueOf(60), "E021");
+
+        Assertions.assertEquals(1, data.size());
+        MarginDto dto = data.get(0);
+        // cost 30 × 40h = 1200 paid; total 60 × 40h = 2400; margin = 1200
+        Assertions.assertEquals(0, BigDecimal.valueOf(1200).compareTo(dto.paid()));
+        Assertions.assertEquals(0, BigDecimal.valueOf(2400).compareTo(dto.total()));
+        Assertions.assertEquals(0, BigDecimal.valueOf(1200).compareTo(dto.margin()));
+    }
+
+    private List<MarginDto> generateSingleMonthHourlyReport(BigDecimal hourlyCost, BigDecimal rate,
+            String internalId) {
+        String start = "2025-06-02";
+        String end = "2025-06-06";
+        ReactAdminParams params = new ReactAdminParams(FILTER_JSON.formatted(start, end), RANGE_JSON.formatted(0, 20),
+                SORT_JSON.formatted("internalId", "ASC"));
+
+        Employee employee = buildEmployee(UUID.randomUUID(), internalId);
+        LocalDate startDate = LocalDate.parse(start);
+        LocalDate endDate = LocalDate.parse(end);
+
+        Mockito.when(holidayService.getHolidaysByCountry(startDate, endDate)).thenReturn(Map.of());
+        Mockito.when(contractService.findByDateBetween(startDate, endDate))
+                .thenReturn(List.of(buildHourlyContract(employee, LocalDate.of(2025, 1, 1), null, hourlyCost)));
+        Mockito.when(ptoRepository.findAllBetweenPeriod(startDate, endDate)).thenReturn(List.of());
+        Mockito.when(overtimeService.findByDateBetween(startDate, endDate)).thenReturn(List.of());
+
+        Assignment assignment = buildAssignment(employee, LocalDate.of(2025, 1, 1), null, rate);
+        Mockito.when(assignmentRepository.findAllBetweenPeriod(startDate, endDate)).thenReturn(List.of(assignment));
+
+        return marginService.generateMarginReport(params).data();
+    }
+
+    private static Contract buildHourlyContract(Employee employee, LocalDate startDate, LocalDate endDate,
+            BigDecimal hourlyCost) {
+        Contract contract = new Contract();
+        contract.setId(UUID.randomUUID());
+        contract.setCompany(COMPANY);
+        contract.setEmployee(employee);
+        contract.setStartDate(startDate);
+        contract.setEndDate(endDate);
+        contract.setActive(true);
+        PaymentSettlement paymentSettlement = new PaymentSettlement();
+        paymentSettlement.setCurrency(Currency.USD);
+        paymentSettlement.setSalary(hourlyCost);
+        paymentSettlement.setModality(Modality.HOUR);
+        contract.addPaymentSettlement(paymentSettlement);
+        return contract;
+    }
+
     private static void validateResult(MarginDto marginDto, YearMonth yearMonth, BigDecimal rate, double hours,
             double ptoHours, BigDecimal paid) {
         Assertions.assertEquals(yearMonth.toString(), marginDto.yearMonth());


### PR DESCRIPTION
**Sub-card:** https://3.basecamp.com/5776473/buckets/37034902/card_tables/cards/10012781795
**Parent story:** https://3.basecamp.com/5776473/buckets/37034902/card_tables/cards/10012609759

## Problem
Hourly-contract employees (`Modality.HOUR`) had their cost treated as zero in two independent backend calculations, producing a **$0 salary** and an **inflated margin** (100% on pass-through engagements where the hourly cost equals the billed rate — e.g. Nicky Jam: $60/h rate, $0 salary, 100% margin). The frontend only displays what the backend returns, so the fix is backend-only; admin-ui and response shapes are unchanged.

## Root cause (two places)
1. **Employee card + detail header** — `EmployeeDto.salary = activeContract.calculateMonthlySalaryInUSD()`, which filters to `MONTHLY`/`USD` and returns `ZERO` for an `HOUR` contract → `calculateMargin(0, rate)` = 100%.
2. **Margin report** — `getSalaries()` → `Contract.toMonthlySalary()` returns `ZERO` for `HOUR`, so `getMarginDto()` counts the full revenue as margin.

## Changes
- **`Contract`** — `calculateHourlyCostInUSD()` exposes the `HOUR`/`USD` settlement salary (the per-hour cost); `getHourlyCostByMonth()` provides it per active month for the report. `calculateMonthlySalaryInUSD()` (the MONTHLY path) is untouched.
- **`MarginService`** — annualization constants (`1850` billable hours, `12` months) named as the single source of truth shared with `calculateMargin`; new `monthlyCostInUSD(Contract)` scales an hourly cost to a monthly equivalent on the same basis (`annualCost = hourlyCost × 1850`); the report computes the hourly salary as `hourlyCost × billable hours` (same basis as `total`), so a pass-through nets to exactly 0%.
- **`EmployeeDto`** — card/detail salary now flows through `MarginService.monthlyCostInUSD(activeContract)`.

## Acceptance criteria
- [x] Hourly employee's cost no longer shown as $0 — card/detail shows the monthly-equivalent cost; report shows `hourlyCost × hours`.
- [x] Margin reflects the real cost instead of treating it as zero.
- [x] Pass-through (cost = billed rate) → **0%** margin (was 100%) — covered by `testCalculateMargin_passThroughHourlyEngagementIsZero` and `testGenerateMarginReport_passThroughHourlyEmployeeHasZeroMargin`.
- [x] Cost below rate → positive proportional margin — `testCalculateMargin_hourlyCostBelowRateIsPositiveAndProportional` (50%) and `testGenerateMarginReport_hourlyCostBelowRateHasPositiveMargin`.
- [x] Consistent across card, detail header, and margin report — card and header share the `EmployeeDto` constructor; report uses the same hourly-cost source.
- [x] Monthly/salaried employees unchanged — `calculateMonthlySalaryInUSD()` left intact; `testCalculateMargin_monthlyContractMarginIsUnchanged` (regression) plus the existing full margin-report test pass.

## Testing
`mvn test` — **304 passed, 0 failures**. New `ContractTest` (6 tests) + 7 new `MarginServiceTest` cases (TDD: pass-through, below-rate, monthly regression, monthly-equivalent conversion, and report-level pass-through/below-rate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)